### PR TITLE
Use `Aprs` prefix for types

### DIFF
--- a/src/callsign.rs
+++ b/src/callsign.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use APRSError;
+use AprsError;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct Callsign {
@@ -18,24 +18,24 @@ impl Callsign {
 }
 
 impl FromStr for Callsign {
-    type Err = APRSError;
+    type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
-        let delimiter = s.find('-'); //.ok_or_else(|| APRSError::EmptyCallsign(s.to_owned()))?;
+        let delimiter = s.find('-'); //.ok_or_else(|| AprsError::EmptyCallsign(s.to_owned()))?;
         if delimiter.is_none() {
             return Ok(Callsign::new(s, None));
         }
 
         let delimiter = delimiter.unwrap();
         if delimiter == 0 {
-            return Err(APRSError::EmptyCallsign(s.to_owned()));
+            return Err(AprsError::EmptyCallsign(s.to_owned()));
         }
 
         let (call, rest) = s.split_at(delimiter);
         let ssid = &rest[1..rest.len()];
 
         if ssid.is_empty() {
-            return Err(APRSError::EmptySSID(s.to_owned()));
+            return Err(AprsError::EmptySSID(s.to_owned()));
         }
 
         Ok(Callsign::new(call, Some(ssid)))
@@ -60,7 +60,7 @@ mod tests {
     fn empty_callsign() {
         assert_eq!(
             "-42".parse::<Callsign>(),
-            Err(APRSError::EmptyCallsign("-42".to_owned()))
+            Err(AprsError::EmptyCallsign("-42".to_owned()))
         );
     }
 
@@ -68,7 +68,7 @@ mod tests {
     fn empty_ssid() {
         assert_eq!(
             "ABCDEF-".parse::<Callsign>(),
-            Err(APRSError::EmptySSID("ABCDEF-".to_owned()))
+            Err(AprsError::EmptySSID("ABCDEF-".to_owned()))
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
-pub enum APRSError {
+pub enum AprsError {
     #[error("Empty Callsign: {0}")]
     EmptyCallsign(String),
     #[error("Empty Callsign SSID: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,11 @@ mod timestamp;
 use std::str::FromStr;
 
 pub use callsign::Callsign;
-pub use error::APRSError;
+pub use error::AprsError;
 pub use message::{APRSData, APRSMessage};
 pub use position::APRSPosition;
 pub use timestamp::Timestamp;
 
-pub fn parse(s: &str) -> Result<APRSMessage, APRSError> {
+pub fn parse(s: &str) -> Result<APRSMessage, AprsError> {
     APRSMessage::from_str(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!     println!("{:#?}", result);
 //!
 //!     // Ok(
-//!     //     APRSMessage {
+//!     //     AprsMessage {
 //!     //         from: Callsign {
 //!     //             call: "ICA3D17F2",
 //!     //             ssid: None
@@ -71,10 +71,10 @@ use std::str::FromStr;
 
 pub use callsign::Callsign;
 pub use error::AprsError;
-pub use message::{APRSMessage, AprsData};
+pub use message::{AprsData, AprsMessage};
 pub use position::AprsPosition;
 pub use timestamp::Timestamp;
 
-pub fn parse(s: &str) -> Result<APRSMessage, AprsError> {
-    APRSMessage::from_str(s)
+pub fn parse(s: &str) -> Result<AprsMessage, AprsError> {
+    AprsMessage::from_str(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!     //             }
 //!     //         ],
 //!     //         data: Position(
-//!     //             APRSPosition {
+//!     //             AprsPosition {
 //!     //                 timestamp: Some(
 //!     //                     HHMMSS(
 //!     //                         7,
@@ -72,7 +72,7 @@ use std::str::FromStr;
 pub use callsign::Callsign;
 pub use error::AprsError;
 pub use message::{APRSData, APRSMessage};
-pub use position::APRSPosition;
+pub use position::AprsPosition;
 pub use timestamp::Timestamp;
 
 pub fn parse(s: &str) -> Result<APRSMessage, AprsError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ use std::str::FromStr;
 
 pub use callsign::Callsign;
 pub use error::AprsError;
-pub use message::{APRSData, APRSMessage};
+pub use message::{APRSMessage, AprsData};
 pub use position::AprsPosition;
 pub use timestamp::Timestamp;
 

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -1,55 +1,55 @@
-use APRSError;
+use AprsError;
 
-pub fn parse_latitude(s: &str) -> Result<f32, APRSError> {
+pub fn parse_latitude(s: &str) -> Result<f32, AprsError> {
     let b = s.as_bytes();
 
     if b.len() != 8 || b[4] as char != '.' {
-        return Err(APRSError::InvalidLatitude(s.to_owned()));
+        return Err(AprsError::InvalidLatitude(s.to_owned()));
     }
 
     let north = match b[7] as char {
         'N' => true,
         'S' => false,
-        _ => return Err(APRSError::InvalidLatitude(s.to_owned())),
+        _ => return Err(AprsError::InvalidLatitude(s.to_owned())),
     };
 
     let deg = s[0..2]
         .parse::<u32>()
-        .map_err(|_| APRSError::InvalidLatitude(s.to_owned()))? as f32;
+        .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
     let min = s[2..4]
         .parse::<u32>()
-        .map_err(|_| APRSError::InvalidLatitude(s.to_owned()))? as f32;
+        .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
     let min_frac = s[5..7]
         .parse::<u32>()
-        .map_err(|_| APRSError::InvalidLatitude(s.to_owned()))? as f32;
+        .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
 
     let value = deg + min / 60. + min_frac / 6_000.;
 
     Ok(if north { value } else { -value })
 }
 
-pub fn parse_longitude(s: &str) -> Result<f32, APRSError> {
+pub fn parse_longitude(s: &str) -> Result<f32, AprsError> {
     let b = s.as_bytes();
 
     if b.len() != 9 || b[5] as char != '.' {
-        return Err(APRSError::InvalidLongitude(s.to_owned()));
+        return Err(AprsError::InvalidLongitude(s.to_owned()));
     }
 
     let east = match b[8] as char {
         'E' => true,
         'W' => false,
-        _ => return Err(APRSError::InvalidLongitude(s.to_owned())),
+        _ => return Err(AprsError::InvalidLongitude(s.to_owned())),
     };
 
     let deg = s[0..3]
         .parse::<u32>()
-        .map_err(|_| APRSError::InvalidLongitude(s.to_owned()))? as f32;
+        .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
     let min = s[3..5]
         .parse::<u32>()
-        .map_err(|_| APRSError::InvalidLongitude(s.to_owned()))? as f32;
+        .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
     let min_frac = s[6..8]
         .parse::<u32>()
-        .map_err(|_| APRSError::InvalidLongitude(s.to_owned()))? as f32;
+        .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
 
     let value = deg + min / 60. + min_frac / 6_000.;
 
@@ -66,11 +66,11 @@ mod tests {
         assert_relative_eq!(parse_latitude("4903.50S").unwrap(), -49.05833);
         assert_eq!(
             parse_latitude("4903.50W"),
-            Err(APRSError::InvalidLatitude("4903.50W".to_owned()))
+            Err(AprsError::InvalidLatitude("4903.50W".to_owned()))
         );
         assert_eq!(
             parse_latitude("4903.50E"),
-            Err(APRSError::InvalidLatitude("4903.50E".to_owned()))
+            Err(AprsError::InvalidLatitude("4903.50E".to_owned()))
         );
         assert_relative_eq!(parse_latitude("0000.00N").unwrap(), 0.0);
         assert_relative_eq!(parse_latitude("0000.00S").unwrap(), 0.0);
@@ -82,11 +82,11 @@ mod tests {
         assert_relative_eq!(parse_longitude("04903.50W").unwrap(), -49.05833);
         assert_eq!(
             parse_longitude("04903.50N"),
-            Err(APRSError::InvalidLongitude("04903.50N".to_owned()))
+            Err(AprsError::InvalidLongitude("04903.50N".to_owned()))
         );
         assert_eq!(
             parse_longitude("04903.50S"),
-            Err(APRSError::InvalidLongitude("04903.50S".to_owned()))
+            Err(AprsError::InvalidLongitude("04903.50S".to_owned()))
         );
         assert_relative_eq!(parse_longitude("00000.00E").unwrap(), 0.0);
         assert_relative_eq!(parse_longitude("00000.00W").unwrap(), 0.0);

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,14 +5,14 @@ use AprsPosition;
 use Callsign;
 
 #[derive(PartialEq, Debug, Clone)]
-pub struct APRSMessage {
+pub struct AprsMessage {
     pub from: Callsign,
     pub to: Callsign,
     pub via: Vec<Callsign>,
     pub data: AprsData,
 }
 
-impl FromStr for APRSMessage {
+impl FromStr for AprsMessage {
     type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
@@ -45,7 +45,7 @@ impl FromStr for APRSMessage {
             .map(AprsData::Position)
             .unwrap_or(AprsData::Unknown);
 
-        Ok(APRSMessage {
+        Ok(AprsMessage {
             from,
             to,
             via,
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn parse() {
-        let result = r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1".parse::<APRSMessage>().unwrap();
+        let result = r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1".parse::<AprsMessage>().unwrap();
         assert_eq!(result.from, Callsign::new("ICA3D17F2", None));
         assert_eq!(result.to, Callsign::new("APRS", None));
         assert_eq!(

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use APRSError;
 use APRSPosition;
+use AprsError;
 use Callsign;
 
 #[derive(PartialEq, Debug, Clone)]
@@ -13,18 +13,18 @@ pub struct APRSMessage {
 }
 
 impl FromStr for APRSMessage {
-    type Err = APRSError;
+    type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
         let header_delimiter = s
             .find(':')
-            .ok_or_else(|| APRSError::InvalidMessage(s.to_owned()))?;
+            .ok_or_else(|| AprsError::InvalidMessage(s.to_owned()))?;
         let (header, rest) = s.split_at(header_delimiter);
         let body = &rest[1..];
 
         let from_delimiter = header
             .find('>')
-            .ok_or_else(|| APRSError::InvalidMessage(s.to_owned()))?;
+            .ok_or_else(|| AprsError::InvalidMessage(s.to_owned()))?;
         let (from, rest) = header.split_at(from_delimiter);
         let from = Callsign::from_str(from)?;
 
@@ -33,7 +33,7 @@ impl FromStr for APRSMessage {
 
         let to = to_and_via
             .first()
-            .ok_or_else(|| APRSError::InvalidMessage(s.to_owned()))?;
+            .ok_or_else(|| AprsError::InvalidMessage(s.to_owned()))?;
         let to = Callsign::from_str(to)?;
 
         let mut via = vec![];

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use APRSPosition;
 use AprsError;
+use AprsPosition;
 use Callsign;
 
 #[derive(PartialEq, Debug, Clone)]
@@ -41,7 +41,7 @@ impl FromStr for APRSMessage {
             via.push(Callsign::from_str(v)?);
         }
 
-        let data = APRSPosition::from_str(body)
+        let data = AprsPosition::from_str(body)
             .map(APRSData::Position)
             .unwrap_or(APRSData::Unknown);
 
@@ -56,7 +56,7 @@ impl FromStr for APRSMessage {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum APRSData {
-    Position(APRSPosition),
+    Position(AprsPosition),
     Unknown,
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -9,7 +9,7 @@ pub struct APRSMessage {
     pub from: Callsign,
     pub to: Callsign,
     pub via: Vec<Callsign>,
-    pub data: APRSData,
+    pub data: AprsData,
 }
 
 impl FromStr for APRSMessage {
@@ -42,8 +42,8 @@ impl FromStr for APRSMessage {
         }
 
         let data = AprsPosition::from_str(body)
-            .map(APRSData::Position)
-            .unwrap_or(APRSData::Unknown);
+            .map(AprsData::Position)
+            .unwrap_or(AprsData::Unknown);
 
         Ok(APRSMessage {
             from,
@@ -55,7 +55,7 @@ impl FromStr for APRSMessage {
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub enum APRSData {
+pub enum AprsData {
     Position(AprsPosition),
     Unknown,
 }
@@ -76,7 +76,7 @@ mod tests {
         );
 
         match result.data {
-            APRSData::Position(position) => {
+            AprsData::Position(position) => {
                 assert_eq!(position.timestamp, Some(Timestamp::HHMMSS(7, 48, 49)));
                 assert_relative_eq!(position.latitude, 48.360166);
                 assert_relative_eq!(position.longitude, 12.408166);

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use lonlat::{parse_latitude, parse_longitude};
-use APRSError;
+use AprsError;
 use Timestamp;
 
 #[derive(PartialEq, Debug, Clone)]
@@ -13,7 +13,7 @@ pub struct APRSPosition {
 }
 
 impl FromStr for APRSPosition {
-    type Err = APRSError;
+    type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
         // parse timestamp if necessary
@@ -34,11 +34,11 @@ impl FromStr for APRSPosition {
         // check for compressed position format
         let is_uncompressed_position = s.chars().take(1).all(|c| c.is_numeric());
         if !is_uncompressed_position {
-            return Err(APRSError::UnsupportedPositionFormat(s.to_owned()));
+            return Err(AprsError::UnsupportedPositionFormat(s.to_owned()));
         }
 
         if s.len() < 19 {
-            return Err(APRSError::InvalidPosition(s.to_owned()));
+            return Err(AprsError::InvalidPosition(s.to_owned()));
         }
 
         // parse position

--- a/src/position.rs
+++ b/src/position.rs
@@ -5,14 +5,14 @@ use AprsError;
 use Timestamp;
 
 #[derive(PartialEq, Debug, Clone)]
-pub struct APRSPosition {
+pub struct AprsPosition {
     pub timestamp: Option<Timestamp>,
     pub latitude: f32,
     pub longitude: f32,
     pub comment: String,
 }
 
-impl FromStr for APRSPosition {
+impl FromStr for AprsPosition {
     type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
@@ -47,7 +47,7 @@ impl FromStr for APRSPosition {
 
         let comment = &s[19..s.len()];
 
-        Ok(APRSPosition {
+        Ok(AprsPosition {
             timestamp,
             latitude,
             longitude,
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn parse() {
-        let result = r"!4903.50N/07201.75W-".parse::<APRSPosition>().unwrap();
+        let result = r"!4903.50N/07201.75W-".parse::<AprsPosition>().unwrap();
         assert_eq!(result.timestamp, None);
         assert_relative_eq!(result.latitude, 49.05833);
         assert_relative_eq!(result.longitude, -72.02916);
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn parse_with_comment() {
         let result = r"!4903.50N/07201.75W-Hello/A=001000"
-            .parse::<APRSPosition>()
+            .parse::<AprsPosition>()
             .unwrap();
         assert_eq!(result.timestamp, None);
         assert_relative_eq!(result.latitude, 49.05833);
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn parse_with_timestamp() {
         let result = r"/074849h4821.61N\01224.49E^322/103/A=003054"
-            .parse::<APRSPosition>()
+            .parse::<AprsPosition>()
             .unwrap();
         assert_eq!(result.timestamp, Some(Timestamp::HHMMSS(7, 48, 49)));
         assert_relative_eq!(result.latitude, 48.360166);

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use APRSError;
+use AprsError;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum Timestamp {
@@ -13,30 +13,30 @@ pub enum Timestamp {
 }
 
 impl FromStr for Timestamp {
-    type Err = APRSError;
+    type Err = AprsError;
 
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
         let b = s.as_bytes();
 
         if b.len() != 7 {
-            return Err(APRSError::InvalidTimestamp(s.to_owned()));
+            return Err(AprsError::InvalidTimestamp(s.to_owned()));
         }
 
         let one = s[0..2]
             .parse::<u8>()
-            .map_err(|_| APRSError::InvalidTimestamp(s.to_owned()))?;
+            .map_err(|_| AprsError::InvalidTimestamp(s.to_owned()))?;
         let two = s[2..4]
             .parse::<u8>()
-            .map_err(|_| APRSError::InvalidTimestamp(s.to_owned()))?;
+            .map_err(|_| AprsError::InvalidTimestamp(s.to_owned()))?;
         let three = s[4..6]
             .parse::<u8>()
-            .map_err(|_| APRSError::InvalidTimestamp(s.to_owned()))?;
+            .map_err(|_| AprsError::InvalidTimestamp(s.to_owned()))?;
 
         Ok(match b[6] as char {
             'z' => Timestamp::DDHHMM(one, two, three),
             'h' => Timestamp::HHMMSS(one, two, three),
             '/' => Timestamp::Unsupported(s.to_owned()),
-            _ => return Err(APRSError::InvalidTimestamp(s.to_owned())),
+            _ => return Err(AprsError::InvalidTimestamp(s.to_owned())),
         })
     }
 }
@@ -67,7 +67,7 @@ mod tests {
     fn invalid_timestamp() {
         assert_eq!(
             "1234567".parse::<Timestamp>(),
-            Err(APRSError::InvalidTimestamp("1234567".to_owned()))
+            Err(AprsError::InvalidTimestamp("1234567".to_owned()))
         );
     }
 
@@ -75,7 +75,7 @@ mod tests {
     fn invalid_timestamp2() {
         assert_eq!(
             "123a56z".parse::<Timestamp>(),
-            Err(APRSError::InvalidTimestamp("123a56z".to_owned()))
+            Err(AprsError::InvalidTimestamp("123a56z".to_owned()))
         );
     }
 }


### PR DESCRIPTION
Rename APRS*** to Aprs*** and APRSMessage to AprsPacket