### PR TITLE
Decrease MSRV to v1.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.42.0  # minimum supported version
+          - 1.38.0  # minimum supported version
           - stable
 
     steps:


### PR DESCRIPTION
Apparently `thiserror` has a lower MSRV than the `failure` crate had.