### PR TITLE
lonlat: Extract `Latitude` and `Longitude` structs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@
 //! }
 //! ```
 
+// `!(-90. ..=90.).contains(&value)` seems worse than `value > 90. || value < -90.`
+#![allow(clippy::manual_range_contains)]
+
 extern crate thiserror;
 
 #[cfg(test)]
@@ -71,6 +74,7 @@ use std::str::FromStr;
 
 pub use callsign::Callsign;
 pub use error::AprsError;
+pub use lonlat::{Latitude, Longitude};
 pub use message::{AprsData, AprsMessage};
 pub use position::AprsPosition;
 pub use timestamp::Timestamp;

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+use std::str::FromStr;
 use AprsError;
 
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
@@ -12,37 +13,41 @@ impl Deref for Latitude {
     }
 }
 
-pub fn parse_latitude(s: &str) -> Result<Latitude, AprsError> {
-    let b = s.as_bytes();
+impl FromStr for Latitude {
+    type Err = AprsError;
 
-    if b.len() != 8 || b[4] as char != '.' {
-        return Err(AprsError::InvalidLatitude(s.to_owned()));
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let b = s.as_bytes();
+
+        if b.len() != 8 || b[4] as char != '.' {
+            return Err(Self::Err::InvalidLatitude(s.to_owned()));
+        }
+
+        let north = match b[7] as char {
+            'N' => true,
+            'S' => false,
+            _ => return Err(Self::Err::InvalidLatitude(s.to_owned())),
+        };
+
+        let deg = s[0..2]
+            .parse::<u32>()
+            .map_err(|_| Self::Err::InvalidLatitude(s.to_owned()))? as f32;
+        let min = s[2..4]
+            .parse::<u32>()
+            .map_err(|_| Self::Err::InvalidLatitude(s.to_owned()))? as f32;
+        let min_frac = s[5..7]
+            .parse::<u32>()
+            .map_err(|_| Self::Err::InvalidLatitude(s.to_owned()))? as f32;
+
+        let value = deg + min / 60. + min_frac / 6_000.;
+        let value = if north { value } else { -value };
+
+        if value > 90. || value < -90. {
+            return Err(Self::Err::InvalidLatitude(s.to_owned()));
+        }
+
+        Ok(Self(value))
     }
-
-    let north = match b[7] as char {
-        'N' => true,
-        'S' => false,
-        _ => return Err(AprsError::InvalidLatitude(s.to_owned())),
-    };
-
-    let deg = s[0..2]
-        .parse::<u32>()
-        .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
-    let min = s[2..4]
-        .parse::<u32>()
-        .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
-    let min_frac = s[5..7]
-        .parse::<u32>()
-        .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
-
-    let value = deg + min / 60. + min_frac / 6_000.;
-    let value = if north { value } else { -value };
-
-    if value > 90. || value < -90. {
-        return Err(AprsError::InvalidLatitude(s.to_owned()));
-    }
-
-    Ok(Latitude(value))
 }
 
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
@@ -56,37 +61,41 @@ impl Deref for Longitude {
     }
 }
 
-pub fn parse_longitude(s: &str) -> Result<Longitude, AprsError> {
-    let b = s.as_bytes();
+impl FromStr for Longitude {
+    type Err = AprsError;
 
-    if b.len() != 9 || b[5] as char != '.' {
-        return Err(AprsError::InvalidLongitude(s.to_owned()));
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let b = s.as_bytes();
+
+        if b.len() != 9 || b[5] as char != '.' {
+            return Err(Self::Err::InvalidLongitude(s.to_owned()));
+        }
+
+        let east = match b[8] as char {
+            'E' => true,
+            'W' => false,
+            _ => return Err(Self::Err::InvalidLongitude(s.to_owned())),
+        };
+
+        let deg = s[0..3]
+            .parse::<u32>()
+            .map_err(|_| Self::Err::InvalidLongitude(s.to_owned()))? as f32;
+        let min = s[3..5]
+            .parse::<u32>()
+            .map_err(|_| Self::Err::InvalidLongitude(s.to_owned()))? as f32;
+        let min_frac = s[6..8]
+            .parse::<u32>()
+            .map_err(|_| Self::Err::InvalidLongitude(s.to_owned()))? as f32;
+
+        let value = deg + min / 60. + min_frac / 6_000.;
+        let value = if east { value } else { -value };
+
+        if value > 180. || value < -180. {
+            return Err(Self::Err::InvalidLongitude(s.to_owned()));
+        }
+
+        Ok(Self(value))
     }
-
-    let east = match b[8] as char {
-        'E' => true,
-        'W' => false,
-        _ => return Err(AprsError::InvalidLongitude(s.to_owned())),
-    };
-
-    let deg = s[0..3]
-        .parse::<u32>()
-        .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
-    let min = s[3..5]
-        .parse::<u32>()
-        .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
-    let min_frac = s[6..8]
-        .parse::<u32>()
-        .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
-
-    let value = deg + min / 60. + min_frac / 6_000.;
-    let value = if east { value } else { -value };
-
-    if value > 180. || value < -180. {
-        return Err(AprsError::InvalidLongitude(s.to_owned()));
-    }
-
-    Ok(Longitude(value))
 }
 
 #[cfg(test)]
@@ -95,33 +104,33 @@ mod tests {
 
     #[test]
     fn test_latitude() {
-        assert_relative_eq!(*parse_latitude("4903.50N").unwrap(), 49.05833);
-        assert_relative_eq!(*parse_latitude("4903.50S").unwrap(), -49.05833);
+        assert_relative_eq!(*"4903.50N".parse::<Latitude>().unwrap(), 49.05833);
+        assert_relative_eq!(*"4903.50S".parse::<Latitude>().unwrap(), -49.05833);
         assert_eq!(
-            parse_latitude("4903.50W"),
+            "4903.50W".parse::<Latitude>(),
             Err(AprsError::InvalidLatitude("4903.50W".to_owned()))
         );
         assert_eq!(
-            parse_latitude("4903.50E"),
+            "4903.50E".parse::<Latitude>(),
             Err(AprsError::InvalidLatitude("4903.50E".to_owned()))
         );
-        assert_relative_eq!(*parse_latitude("0000.00N").unwrap(), 0.0);
-        assert_relative_eq!(*parse_latitude("0000.00S").unwrap(), 0.0);
+        assert_relative_eq!(*"0000.00N".parse::<Latitude>().unwrap(), 0.0);
+        assert_relative_eq!(*"0000.00S".parse::<Latitude>().unwrap(), 0.0);
     }
 
     #[test]
     fn test_longitude() {
-        assert_relative_eq!(*parse_longitude("12903.50E").unwrap(), 129.05833);
-        assert_relative_eq!(*parse_longitude("04903.50W").unwrap(), -49.05833);
+        assert_relative_eq!(*"12903.50E".parse::<Longitude>().unwrap(), 129.05833);
+        assert_relative_eq!(*"04903.50W".parse::<Longitude>().unwrap(), -49.05833);
         assert_eq!(
-            parse_longitude("04903.50N"),
+            "04903.50N".parse::<Longitude>(),
             Err(AprsError::InvalidLongitude("04903.50N".to_owned()))
         );
         assert_eq!(
-            parse_longitude("04903.50S"),
+            "04903.50S".parse::<Longitude>(),
             Err(AprsError::InvalidLongitude("04903.50S".to_owned()))
         );
-        assert_relative_eq!(*parse_longitude("00000.00E").unwrap(), 0.0);
-        assert_relative_eq!(*parse_longitude("00000.00W").unwrap(), 0.0);
+        assert_relative_eq!(*"00000.00E".parse::<Longitude>().unwrap(), 0.0);
+        assert_relative_eq!(*"00000.00W".parse::<Longitude>().unwrap(), 0.0);
     }
 }

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -1,6 +1,18 @@
+use std::ops::Deref;
 use AprsError;
 
-pub fn parse_latitude(s: &str) -> Result<f32, AprsError> {
+#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
+pub struct Latitude(f32);
+
+impl Deref for Latitude {
+    type Target = f32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub fn parse_latitude(s: &str) -> Result<Latitude, AprsError> {
     let b = s.as_bytes();
 
     if b.len() != 8 || b[4] as char != '.' {
@@ -24,11 +36,27 @@ pub fn parse_latitude(s: &str) -> Result<f32, AprsError> {
         .map_err(|_| AprsError::InvalidLatitude(s.to_owned()))? as f32;
 
     let value = deg + min / 60. + min_frac / 6_000.;
+    let value = if north { value } else { -value };
 
-    Ok(if north { value } else { -value })
+    if value > 90. || value < -90. {
+        return Err(AprsError::InvalidLatitude(s.to_owned()));
+    }
+
+    Ok(Latitude(value))
 }
 
-pub fn parse_longitude(s: &str) -> Result<f32, AprsError> {
+#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
+pub struct Longitude(f32);
+
+impl Deref for Longitude {
+    type Target = f32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub fn parse_longitude(s: &str) -> Result<Longitude, AprsError> {
     let b = s.as_bytes();
 
     if b.len() != 9 || b[5] as char != '.' {
@@ -52,8 +80,13 @@ pub fn parse_longitude(s: &str) -> Result<f32, AprsError> {
         .map_err(|_| AprsError::InvalidLongitude(s.to_owned()))? as f32;
 
     let value = deg + min / 60. + min_frac / 6_000.;
+    let value = if east { value } else { -value };
 
-    Ok(if east { value } else { -value })
+    if value > 180. || value < -180. {
+        return Err(AprsError::InvalidLongitude(s.to_owned()));
+    }
+
+    Ok(Longitude(value))
 }
 
 #[cfg(test)]
@@ -62,8 +95,8 @@ mod tests {
 
     #[test]
     fn test_latitude() {
-        assert_relative_eq!(parse_latitude("4903.50N").unwrap(), 49.05833);
-        assert_relative_eq!(parse_latitude("4903.50S").unwrap(), -49.05833);
+        assert_relative_eq!(*parse_latitude("4903.50N").unwrap(), 49.05833);
+        assert_relative_eq!(*parse_latitude("4903.50S").unwrap(), -49.05833);
         assert_eq!(
             parse_latitude("4903.50W"),
             Err(AprsError::InvalidLatitude("4903.50W".to_owned()))
@@ -72,14 +105,14 @@ mod tests {
             parse_latitude("4903.50E"),
             Err(AprsError::InvalidLatitude("4903.50E".to_owned()))
         );
-        assert_relative_eq!(parse_latitude("0000.00N").unwrap(), 0.0);
-        assert_relative_eq!(parse_latitude("0000.00S").unwrap(), 0.0);
+        assert_relative_eq!(*parse_latitude("0000.00N").unwrap(), 0.0);
+        assert_relative_eq!(*parse_latitude("0000.00S").unwrap(), 0.0);
     }
 
     #[test]
     fn test_longitude() {
-        assert_relative_eq!(parse_longitude("12903.50E").unwrap(), 129.05833);
-        assert_relative_eq!(parse_longitude("04903.50W").unwrap(), -49.05833);
+        assert_relative_eq!(*parse_longitude("12903.50E").unwrap(), 129.05833);
+        assert_relative_eq!(*parse_longitude("04903.50W").unwrap(), -49.05833);
         assert_eq!(
             parse_longitude("04903.50N"),
             Err(AprsError::InvalidLongitude("04903.50N".to_owned()))
@@ -88,7 +121,7 @@ mod tests {
             parse_longitude("04903.50S"),
             Err(AprsError::InvalidLongitude("04903.50S".to_owned()))
         );
-        assert_relative_eq!(parse_longitude("00000.00E").unwrap(), 0.0);
-        assert_relative_eq!(parse_longitude("00000.00W").unwrap(), 0.0);
+        assert_relative_eq!(*parse_longitude("00000.00E").unwrap(), 0.0);
+        assert_relative_eq!(*parse_longitude("00000.00W").unwrap(), 0.0);
     }
 }

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -114,6 +114,10 @@ mod tests {
             "4903.50E".parse::<Latitude>(),
             Err(AprsError::InvalidLatitude("4903.50E".to_owned()))
         );
+        assert_eq!(
+            "9903.50N".parse::<Latitude>(),
+            Err(AprsError::InvalidLatitude("9903.50N".to_owned()))
+        );
         assert_relative_eq!(*"0000.00N".parse::<Latitude>().unwrap(), 0.0);
         assert_relative_eq!(*"0000.00S".parse::<Latitude>().unwrap(), 0.0);
     }
@@ -129,6 +133,10 @@ mod tests {
         assert_eq!(
             "04903.50S".parse::<Longitude>(),
             Err(AprsError::InvalidLongitude("04903.50S".to_owned()))
+        );
+        assert_eq!(
+            "18903.50E".parse::<Longitude>(),
+            Err(AprsError::InvalidLongitude("18903.50E".to_owned()))
         );
         assert_relative_eq!(*"00000.00E".parse::<Longitude>().unwrap(), 0.0);
         assert_relative_eq!(*"00000.00W".parse::<Longitude>().unwrap(), 0.0);

--- a/src/message.rs
+++ b/src/message.rs
@@ -78,8 +78,8 @@ mod tests {
         match result.data {
             AprsData::Position(position) => {
                 assert_eq!(position.timestamp, Some(Timestamp::HHMMSS(7, 48, 49)));
-                assert_relative_eq!(position.latitude, 48.360166);
-                assert_relative_eq!(position.longitude, 12.408166);
+                assert_relative_eq!(*position.latitude, 48.360166);
+                assert_relative_eq!(*position.longitude, 12.408166);
                 assert_eq!(
                     position.comment,
                     "322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1"

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,14 +1,14 @@
 use std::str::FromStr;
 
-use lonlat::{parse_latitude, parse_longitude};
+use lonlat::{parse_latitude, parse_longitude, Latitude, Longitude};
 use AprsError;
 use Timestamp;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct AprsPosition {
     pub timestamp: Option<Timestamp>,
-    pub latitude: f32,
-    pub longitude: f32,
+    pub latitude: Latitude,
+    pub longitude: Longitude,
     pub comment: String,
 }
 
@@ -64,8 +64,8 @@ mod tests {
     fn parse() {
         let result = r"!4903.50N/07201.75W-".parse::<AprsPosition>().unwrap();
         assert_eq!(result.timestamp, None);
-        assert_relative_eq!(result.latitude, 49.05833);
-        assert_relative_eq!(result.longitude, -72.02916);
+        assert_relative_eq!(*result.latitude, 49.05833);
+        assert_relative_eq!(*result.longitude, -72.02916);
         assert_eq!(result.comment, "");
     }
 
@@ -75,8 +75,8 @@ mod tests {
             .parse::<AprsPosition>()
             .unwrap();
         assert_eq!(result.timestamp, None);
-        assert_relative_eq!(result.latitude, 49.05833);
-        assert_relative_eq!(result.longitude, -72.02916);
+        assert_relative_eq!(*result.latitude, 49.05833);
+        assert_relative_eq!(*result.longitude, -72.02916);
         assert_eq!(result.comment, "Hello/A=001000");
     }
 
@@ -86,8 +86,8 @@ mod tests {
             .parse::<AprsPosition>()
             .unwrap();
         assert_eq!(result.timestamp, Some(Timestamp::HHMMSS(7, 48, 49)));
-        assert_relative_eq!(result.latitude, 48.360166);
-        assert_relative_eq!(result.longitude, 12.408166);
+        assert_relative_eq!(*result.latitude, 48.360166);
+        assert_relative_eq!(*result.longitude, 12.408166);
         assert_eq!(result.comment, "322/103/A=003054");
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use lonlat::{parse_latitude, parse_longitude, Latitude, Longitude};
+use lonlat::{Latitude, Longitude};
 use AprsError;
 use Timestamp;
 
@@ -42,8 +42,8 @@ impl FromStr for AprsPosition {
         }
 
         // parse position
-        let latitude = parse_latitude(&s[0..8])?;
-        let longitude = parse_longitude(&s[9..18])?;
+        let latitude = s[0..8].parse()?;
+        let longitude = s[9..18].parse()?;
 
         let comment = &s[19..s.len()];
 


### PR DESCRIPTION
These can be used to ensure in a type-safe way that they are always within valid values.