### PR TITLE
Raise minimum Rust version to v1.52.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.38.0  # minimum supported version
+          - 1.52.0  # minimum supported version
           - stable
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/Turbo87/aprs-parser-rs/"
 repository = "https://github.com/Turbo87/aprs-parser-rs.git"
 license = "MIT/Apache-2.0"
 exclude = [".gitignore", ".travis.yml"]
+rust-version = "1.52.0"
 
 [dependencies]
 thiserror = "1.0.32"


### PR DESCRIPTION
This is required to be able to use `.split_once()`