### PR TITLE
Fix README code example and change message id to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fn main() {
     println!("{:#?}", result);
 
     // Ok(
-    //     APRSMessage {
+    //     AprsPacket {
     //         from: Callsign {
     //             call: "ICA3D17F2",
     //             ssid: None
@@ -44,7 +44,7 @@ fn main() {
     //             }
     //         ],
     //         data: Position(
-    //             APRSPosition {
+    //             AprsPosition {
     //                 timestamp: Some(
     //                     HHMMSS(
     //                         7,
@@ -52,8 +52,11 @@ fn main() {
     //                         49
     //                     )
     //                 ),
-    //                 latitude: 48.360165,
-    //                 longitude: 12.408166,
+	//                 messaging_supported: false
+    //                 latitude: Latitude(48.360165),
+    //                 longitude: Longitude(12.408166),
+	//                 symbol_table: '\\',
+	//                 symbol_code: '^',
     //                 comment: "322/103/A=003054"
     //             }
     //         )

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ fn main() {
     //                         49
     //                     )
     //                 ),
-	//                 messaging_supported: false
+    //                 messaging_supported: false
     //                 latitude: Latitude(48.360165),
     //                 longitude: Longitude(12.408166),
-	//                 symbol_table: '\\',
-	//                 symbol_code: '^',
+    //                 symbol_table: '\\',
+    //                 symbol_code: '^',
     //                 comment: "322/103/A=003054"
     //             }
     //         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,8 +18,6 @@ pub enum AprsError {
     InvalidPacket(String),
     #[error("Invalid Message Destination: {0}")]
     InvalidMessageDestination(String),
-    #[error("Invalid Message ID: {0}")]
-    InvalidMessageId(String),
 }
 
 #[derive(Debug, PartialEq, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,11 @@
 //!     //                         49
 //!     //                     )
 //!     //                 ),
-//!     //                 latitude: 48.360165,
-//!     //                 longitude: 12.408166,
+//!     //                 messaging_supported: false,
+//!     //                 latitude: Latitude(48.360165),
+//!     //                 longitude: Longitude(12.408166),
+//!     //                 symbol_table: '\\',
+//!     //                 symbol_code: '^',
 //!     //                 comment: "322/103/A=003054"
 //!     //             }
 //!     //         )

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn parse_message() {
         let result =
-            r"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {32975"
+            r"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {3a2B975"
                 .parse::<AprsPacket>()
                 .unwrap();
         assert_eq!(result.from, Callsign::new("ICA3D17F2", None));
@@ -149,7 +149,7 @@ mod tests {
             AprsData::Message(msg) => {
                 assert_eq!(msg.addressee, "DEST");
                 assert_eq!(msg.text, "Hello World! This msg has a : colon ");
-                assert_eq!(msg.id, Some(32975));
+                assert_eq!(msg.id, Some("3a2B975".to_string()));
             }
             _ => panic!("Unexpected data type"),
         }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -149,7 +149,7 @@ mod tests {
             AprsData::Message(msg) => {
                 assert_eq!(msg.addressee, "DEST");
                 assert_eq!(msg.text, "Hello World! This msg has a : colon ");
-                assert_eq!(msg.id, Some("3a2B975".to_string()));
+                assert_eq!(msg.id.as_deref(), Some("3a2B975"));
             }
             _ => panic!("Unexpected data type"),
         }


### PR DESCRIPTION
Two changes:

- The code examples in the README/lib.rs have become out of date. I updated them in this PR
- I changed the message id from an integer to a string. There's nothing actually saying it needs to be an int, so this will prevent it from rejecting valid packets.

I probably should have done this in two PRs but I figured the changes were small enough to combine them. I can break this apart if you want. Thanks!