### PR TITLE
Handle APRS packets consisting of arbitrary bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ extern crate aprs_parser;
 
 fn main() {
     let result = aprs_parser::parse(
-        r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
+        r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054".as_bytes()
     );
 
     println!("{:#?}", result);

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ extern crate aprs_parser;
 
 fn main() {
     let result = aprs_parser::parse(
-        r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054".as_bytes()
+        br"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
     );
 
     println!("{:#?}", result);

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -2,7 +2,7 @@ extern crate aprs_parser;
 
 fn main() {
     let result = aprs_parser::parse(
-        r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054",
+        r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054".as_bytes(),
     );
 
     println!("{:#?}", result);

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -2,7 +2,7 @@ extern crate aprs_parser;
 
 fn main() {
     let result = aprs_parser::parse(
-        r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054".as_bytes(),
+        br"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054",
     );
 
     println!("{:#?}", result);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,0 +1,5 @@
+// functions for working with byte arrays
+
+pub fn parse_bytes<T: std::str::FromStr>(b: &[u8]) -> Option<T> {
+    std::str::from_utf8(b).ok()?.parse().ok()
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum EncodeError {
     InvalidLongitude(f32),
     #[error("Invalid Aprs Data")]
     InvalidData,
+    #[error("Invalid Message Addressee: {0:?}")]
+    InvalidMessageAddressee(Vec<u8>),
     #[error(transparent)]
-    Format(#[from] std::io::Error),
+    Write(#[from] std::io::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,30 @@
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum AprsError {
-    #[error("Empty Callsign: {0}")]
+    #[error("Non-UTF8 Callsign: {0:?}")]
+    NonUtf8Callsign(Vec<u8>),
+    #[error("Empty Callsign: {0:?}")]
     EmptyCallsign(String),
-    #[error("Empty Callsign SSID: {0}")]
+    #[error("Empty Callsign SSID: {0:?}")]
     EmptySSID(String),
-    #[error("Invalid Timestamp: {0}")]
-    InvalidTimestamp(String),
-    #[error("Unsupported Position Format: {0}")]
-    UnsupportedPositionFormat(String),
-    #[error("Invalid Position: {0}")]
-    InvalidPosition(String),
-    #[error("Invalid Latitude: {0}")]
-    InvalidLatitude(String),
-    #[error("Invalid Longitude: {0}")]
-    InvalidLongitude(String),
-    #[error("Invalid Packet: {0}")]
-    InvalidPacket(String),
-    #[error("Invalid Message Destination: {0}")]
-    InvalidMessageDestination(String),
+    #[error("Invalid Timestamp: {0:?}")]
+    InvalidTimestamp(Vec<u8>),
+    #[error("Unsupported Position Format: {0:?}")]
+    UnsupportedPositionFormat(Vec<u8>),
+    #[error("Invalid Position: {0:?}")]
+    InvalidPosition(Vec<u8>),
+    #[error("Invalid Latitude: {0:?}")]
+    InvalidLatitude(Vec<u8>),
+    #[error("Invalid Longitude: {0:?}")]
+    InvalidLongitude(Vec<u8>),
+    #[error("Invalid Packet: {0:?}")]
+    InvalidPacket(Vec<u8>),
+    #[error("Invalid Message Destination: {0:?}")]
+    InvalidMessageDestination(Vec<u8>),
+    #[error("Invalid Message ID: {0:?}")]
+    InvalidMessageId(Vec<u8>),
 }
 
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum EncodeError {
     #[error("Invalid Latitude: {0}")]
     InvalidLatitude(f32),
@@ -29,5 +33,5 @@ pub enum EncodeError {
     #[error("Invalid Aprs Data")]
     InvalidData,
     #[error(transparent)]
-    Format(#[from] std::fmt::Error),
+    Format(#[from] std::io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! fn main() {
 //!     let result = aprs_parser::parse(
-//!         r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
+//!         r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054".as_bytes()
 //!     );
 //!
 //!     println!("{:#?}", result);
@@ -66,6 +66,7 @@ extern crate thiserror;
 #[macro_use]
 extern crate approx;
 
+mod bytes;
 mod callsign;
 mod error;
 mod lonlat;
@@ -74,7 +75,7 @@ mod packet;
 mod position;
 mod timestamp;
 
-use std::str::FromStr;
+use std::convert::TryFrom;
 
 pub use callsign::Callsign;
 pub use error::{AprsError, EncodeError};
@@ -84,6 +85,6 @@ pub use packet::{AprsData, AprsPacket};
 pub use position::AprsPosition;
 pub use timestamp::Timestamp;
 
-pub fn parse(s: &str) -> Result<AprsPacket, AprsError> {
-    AprsPacket::from_str(s)
+pub fn parse(b: &[u8]) -> Result<AprsPacket, AprsError> {
+    AprsPacket::try_from(b)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! fn main() {
 //!     let result = aprs_parser::parse(
-//!         r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054".as_bytes()
+//!         br"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
 //!     );
 //!
 //!     println!("{:#?}", result);

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -131,40 +131,28 @@ mod tests {
 
     #[test]
     fn test_latitude() {
-        assert_relative_eq!(
-            *Latitude::try_from("4903.50N".as_bytes()).unwrap(),
-            49.05833
-        );
-        assert_relative_eq!(
-            *Latitude::try_from("4903.50S".as_bytes()).unwrap(),
-            -49.05833
-        );
+        assert_relative_eq!(*Latitude::try_from(&b"4903.50N"[..]).unwrap(), 49.05833);
+        assert_relative_eq!(*Latitude::try_from(&b"4903.50S"[..]).unwrap(), -49.05833);
         assert_eq!(
-            Latitude::try_from("4903.50W".as_bytes()),
+            Latitude::try_from(&b"4903.50W"[..]),
             Err(AprsError::InvalidLatitude(b"4903.50W".to_vec()))
         );
         assert_eq!(
-            Latitude::try_from("4903.50E".as_bytes()),
+            Latitude::try_from(&b"4903.50E"[..]),
             Err(AprsError::InvalidLatitude(b"4903.50E".to_vec()))
         );
         assert_eq!(
-            Latitude::try_from("9903.50N".as_bytes()),
+            Latitude::try_from(&b"9903.50N"[..]),
             Err(AprsError::InvalidLatitude(b"9903.50N".to_vec()))
         );
-        assert_relative_eq!(*Latitude::try_from("0000.00N".as_bytes()).unwrap(), 0.0);
-        assert_relative_eq!(*Latitude::try_from("0000.00S".as_bytes()).unwrap(), 0.0);
+        assert_relative_eq!(*Latitude::try_from(&b"0000.00N"[..]).unwrap(), 0.0);
+        assert_relative_eq!(*Latitude::try_from(&b"0000.00S"[..]).unwrap(), 0.0);
     }
 
     #[test]
     fn test_longitude() {
-        assert_relative_eq!(
-            *Longitude::try_from(b"12903.50E".as_slice()).unwrap(),
-            129.05833
-        );
-        assert_relative_eq!(
-            *Longitude::try_from(b"04903.50W".as_slice()).unwrap(),
-            -49.05833
-        );
+        assert_relative_eq!(*Longitude::try_from(&b"12903.50E"[..]).unwrap(), 129.05833);
+        assert_relative_eq!(*Longitude::try_from(&b"04903.50W"[..]).unwrap(), -49.05833);
         assert_eq!(
             Longitude::try_from(&b"04903.50N"[..]),
             Err(AprsError::InvalidLongitude(b"04903.50N".to_vec()))

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -1,5 +1,7 @@
+use std::convert::TryFrom;
 use std::ops::Deref;
-use std::str::FromStr;
+
+use bytes::parse_bytes;
 use AprsError;
 use EncodeError;
 
@@ -14,37 +16,33 @@ impl Deref for Latitude {
     }
 }
 
-impl FromStr for Latitude {
-    type Err = AprsError;
+impl TryFrom<&[u8]> for Latitude {
+    type Error = AprsError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let b = s.as_bytes();
-
-        if b.len() != 8 || b[4] as char != '.' {
-            return Err(Self::Err::InvalidLatitude(s.to_owned()));
+    fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
+        if b.len() != 8 || b[4] != b'.' {
+            return Err(Self::Error::InvalidLatitude(b.to_owned()));
         }
 
-        let north = match b[7] as char {
-            'N' => true,
-            'S' => false,
-            _ => return Err(Self::Err::InvalidLatitude(s.to_owned())),
+        let north = match b[7] {
+            b'N' => true,
+            b'S' => false,
+            _ => return Err(Self::Error::InvalidLatitude(b.to_owned())),
         };
 
-        let deg = s[0..2]
-            .parse::<u32>()
-            .map_err(|_| Self::Err::InvalidLatitude(s.to_owned()))? as f32;
-        let min = s[2..4]
-            .parse::<u32>()
-            .map_err(|_| Self::Err::InvalidLatitude(s.to_owned()))? as f32;
-        let min_frac = s[5..7]
-            .parse::<u32>()
-            .map_err(|_| Self::Err::InvalidLatitude(s.to_owned()))? as f32;
+        let deg = parse_bytes::<u32>(&b[0..2])
+            .ok_or_else(|| Self::Error::InvalidLatitude(b.to_owned()))? as f32;
+        let min = parse_bytes::<u32>(&b[2..4])
+            .ok_or_else(|| Self::Error::InvalidLatitude(b.to_owned()))? as f32;
+        let min_frac = parse_bytes::<u32>(&b[5..7])
+            .ok_or_else(|| Self::Error::InvalidLatitude(b.to_owned()))?
+            as f32;
 
         let value = deg + min / 60. + min_frac / 6_000.;
         let value = if north { value } else { -value };
 
         if value > 90. || value < -90. {
-            return Err(Self::Err::InvalidLatitude(s.to_owned()));
+            return Err(Self::Error::InvalidLatitude(b.to_owned()));
         }
 
         Ok(Self(value))
@@ -62,37 +60,33 @@ impl Deref for Longitude {
     }
 }
 
-impl FromStr for Longitude {
-    type Err = AprsError;
+impl TryFrom<&[u8]> for Longitude {
+    type Error = AprsError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let b = s.as_bytes();
-
-        if b.len() != 9 || b[5] as char != '.' {
-            return Err(Self::Err::InvalidLongitude(s.to_owned()));
+    fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
+        if b.len() != 9 || b[5] != b'.' {
+            return Err(Self::Error::InvalidLongitude(b.to_owned()));
         }
 
-        let east = match b[8] as char {
-            'E' => true,
-            'W' => false,
-            _ => return Err(Self::Err::InvalidLongitude(s.to_owned())),
+        let east = match b[8] {
+            b'E' => true,
+            b'W' => false,
+            _ => return Err(Self::Error::InvalidLongitude(b.to_owned())),
         };
 
-        let deg = s[0..3]
-            .parse::<u32>()
-            .map_err(|_| Self::Err::InvalidLongitude(s.to_owned()))? as f32;
-        let min = s[3..5]
-            .parse::<u32>()
-            .map_err(|_| Self::Err::InvalidLongitude(s.to_owned()))? as f32;
-        let min_frac = s[6..8]
-            .parse::<u32>()
-            .map_err(|_| Self::Err::InvalidLongitude(s.to_owned()))? as f32;
+        let deg = parse_bytes::<u32>(&b[0..3])
+            .ok_or_else(|| Self::Error::InvalidLongitude(b.to_owned()))? as f32;
+        let min = parse_bytes::<u32>(&b[3..5])
+            .ok_or_else(|| Self::Error::InvalidLongitude(b.to_owned()))? as f32;
+        let min_frac = parse_bytes::<u32>(&b[6..8])
+            .ok_or_else(|| Self::Error::InvalidLongitude(b.to_owned()))?
+            as f32;
 
         let value = deg + min / 60. + min_frac / 6_000.;
         let value = if east { value } else { -value };
 
         if value > 180. || value < -180. {
-            return Err(Self::Err::InvalidLongitude(s.to_owned()));
+            return Err(Self::Error::InvalidLongitude(b.to_owned()));
         }
 
         Ok(Self(value))
@@ -137,86 +131,101 @@ mod tests {
 
     #[test]
     fn test_latitude() {
-        assert_relative_eq!(*"4903.50N".parse::<Latitude>().unwrap(), 49.05833);
-        assert_relative_eq!(*"4903.50S".parse::<Latitude>().unwrap(), -49.05833);
-        assert_eq!(
-            "4903.50W".parse::<Latitude>(),
-            Err(AprsError::InvalidLatitude("4903.50W".to_owned()))
+        assert_relative_eq!(
+            *Latitude::try_from("4903.50N".as_bytes()).unwrap(),
+            49.05833
+        );
+        assert_relative_eq!(
+            *Latitude::try_from("4903.50S".as_bytes()).unwrap(),
+            -49.05833
         );
         assert_eq!(
-            "4903.50E".parse::<Latitude>(),
-            Err(AprsError::InvalidLatitude("4903.50E".to_owned()))
+            Latitude::try_from("4903.50W".as_bytes()),
+            Err(AprsError::InvalidLatitude(b"4903.50W".to_vec()))
         );
         assert_eq!(
-            "9903.50N".parse::<Latitude>(),
-            Err(AprsError::InvalidLatitude("9903.50N".to_owned()))
+            Latitude::try_from("4903.50E".as_bytes()),
+            Err(AprsError::InvalidLatitude(b"4903.50E".to_vec()))
         );
-        assert_relative_eq!(*"0000.00N".parse::<Latitude>().unwrap(), 0.0);
-        assert_relative_eq!(*"0000.00S".parse::<Latitude>().unwrap(), 0.0);
+        assert_eq!(
+            Latitude::try_from("9903.50N".as_bytes()),
+            Err(AprsError::InvalidLatitude(b"9903.50N".to_vec()))
+        );
+        assert_relative_eq!(*Latitude::try_from("0000.00N".as_bytes()).unwrap(), 0.0);
+        assert_relative_eq!(*Latitude::try_from("0000.00S".as_bytes()).unwrap(), 0.0);
     }
 
     #[test]
     fn test_longitude() {
-        assert_relative_eq!(*"12903.50E".parse::<Longitude>().unwrap(), 129.05833);
-        assert_relative_eq!(*"04903.50W".parse::<Longitude>().unwrap(), -49.05833);
-        assert_eq!(
-            "04903.50N".parse::<Longitude>(),
-            Err(AprsError::InvalidLongitude("04903.50N".to_owned()))
+        assert_relative_eq!(
+            *Longitude::try_from(b"12903.50E".as_slice()).unwrap(),
+            129.05833
+        );
+        assert_relative_eq!(
+            *Longitude::try_from(b"04903.50W".as_slice()).unwrap(),
+            -49.05833
         );
         assert_eq!(
-            "04903.50S".parse::<Longitude>(),
-            Err(AprsError::InvalidLongitude("04903.50S".to_owned()))
+            Longitude::try_from(&b"04903.50N"[..]),
+            Err(AprsError::InvalidLongitude(b"04903.50N".to_vec()))
         );
         assert_eq!(
-            "18903.50E".parse::<Longitude>(),
-            Err(AprsError::InvalidLongitude("18903.50E".to_owned()))
+            Longitude::try_from(&b"04903.50S"[..]),
+            Err(AprsError::InvalidLongitude(b"04903.50S".to_vec()))
         );
-        assert_relative_eq!(*"00000.00E".parse::<Longitude>().unwrap(), 0.0);
-        assert_relative_eq!(*"00000.00W".parse::<Longitude>().unwrap(), 0.0);
+        assert_eq!(
+            Longitude::try_from(&b"18903.50E"[..]),
+            Err(AprsError::InvalidLongitude(b"18903.50E".to_vec()))
+        );
+        assert_relative_eq!(*Longitude::try_from(&b"00000.00E"[..]).unwrap(), 0.0);
+        assert_relative_eq!(*Longitude::try_from(&b"00000.00W"[..]).unwrap(), 0.0);
     }
 
     #[test]
     fn test_encode_latitude() {
         assert_eq!(
-            encode_latitude(Latitude(49.05833)),
-            Ok("4903.50N".to_string())
+            encode_latitude(Latitude(49.05833)).unwrap(),
+            "4903.50N".to_string()
         );
         assert_eq!(
-            encode_latitude(Latitude(-49.05833)),
-            Ok("4903.50S".to_string())
+            encode_latitude(Latitude(-49.05833)).unwrap(),
+            "4903.50S".to_string()
         );
-        assert_eq!(
+        assert!(matches!(
             encode_latitude(Latitude(-90.1)),
-            Err(EncodeError::InvalidLatitude(-90.1))
-        );
-        assert_eq!(
+            Err(EncodeError::InvalidLatitude(x)) if x == -90.1
+        ));
+        assert!(matches!(
             encode_latitude(Latitude(90.1)),
-            Err(EncodeError::InvalidLatitude(90.1))
+            Err(EncodeError::InvalidLatitude(x)) if x == 90.1
+        ));
+        assert_eq!(
+            encode_latitude(Latitude(0.0)).unwrap(),
+            "0000.00N".to_string()
         );
-        assert_eq!(encode_latitude(Latitude(0.0)), Ok("0000.00N".to_string()));
     }
 
     #[test]
     fn test_encode_longitude() {
         assert_eq!(
-            encode_longitude(Longitude(129.05833)),
-            Ok("12903.50E".to_string())
+            encode_longitude(Longitude(129.05833)).unwrap(),
+            "12903.50E".to_string()
         );
         assert_eq!(
-            encode_longitude(Longitude(-49.05833)),
-            Ok("04903.50W".to_string())
+            encode_longitude(Longitude(-49.05833)).unwrap(),
+            "04903.50W".to_string()
         );
-        assert_eq!(
+        assert!(matches!(
             encode_longitude(Longitude(-180.1)),
-            Err(EncodeError::InvalidLongitude(-180.1))
-        );
-        assert_eq!(
+            Err(EncodeError::InvalidLongitude(x)) if x == -180.1
+        ));
+        assert!(matches!(
             encode_longitude(Longitude(180.1)),
-            Err(EncodeError::InvalidLongitude(180.1))
-        );
+            Err(EncodeError::InvalidLongitude(x)) if x == 180.1
+        ));
         assert_eq!(
-            encode_longitude(Longitude(0.0)),
-            Ok("00000.00E".to_string())
+            encode_longitude(Longitude(0.0)).unwrap(),
+            "00000.00E".to_string()
         );
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,38 +1,38 @@
+use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 
 use AprsError;
-use FromStr;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AprsMessage {
-    pub addressee: String,
-    pub text: String,
-    pub id: Option<String>,
+    pub addressee: Vec<u8>,
+    pub text: Vec<u8>,
+    pub id: Option<Vec<u8>>,
 }
 
-impl FromStr for AprsMessage {
-    type Err = AprsError;
+impl TryFrom<&[u8]> for AprsMessage {
+    type Error = AprsError;
 
-    fn from_str(s: &str) -> Result<Self, AprsError> {
-        let mut splitter = s.splitn(2, ':');
+    fn try_from(b: &[u8]) -> Result<Self, AprsError> {
+        let mut splitter = b.splitn(2, |x| *x == b':');
 
-        let addressee = match splitter.next() {
-            Some(x) => x,
+        let mut addressee = match splitter.next() {
+            Some(x) => x.to_vec(),
             None => {
-                return Err(AprsError::InvalidMessageDestination("".to_string()));
+                return Err(AprsError::InvalidMessageDestination(vec![]));
             }
         };
 
         if addressee.len() != 9 {
-            return Err(AprsError::InvalidMessageDestination(addressee.to_string()));
+            return Err(AprsError::InvalidMessageDestination(addressee.to_owned()));
         }
 
-        let addressee = addressee.trim().to_string();
+        remove_trailing_spaces(&mut addressee);
 
-        let text = splitter.next().unwrap_or("");
-        let mut text_splitter = text.splitn(2, '{');
-        let text = text_splitter.next().unwrap_or("").to_string();
-        let id = text_splitter.next().map(|s| s.to_string());
+        let text = splitter.next().unwrap_or(&[]);
+        let mut text_splitter = text.splitn(2, |x| *x == b'{');
+        let text = text_splitter.next().unwrap_or(&[]).to_vec();
+        let id = text_splitter.next().map(|x| x.to_vec());
 
         Ok(Self {
             addressee,
@@ -42,6 +42,37 @@ impl FromStr for AprsMessage {
     }
 }
 
+impl Display for AprsMessage {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            ":{: <9}:{}",
+            String::from_utf8_lossy(&self.addressee),
+            String::from_utf8_lossy(&self.text)
+        )?;
+
+        if let Some(id) = &self.id {
+            write!(f, "{{{}", String::from_utf8_lossy(id))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn remove_trailing_spaces(arr: &mut Vec<u8>) {
+    let mut space_count = 0;
+
+    for b in arr.iter_mut().rev() {
+        if *b == b' ' {
+            space_count += 1;
+        } else {
+            break;
+        }
+    }
+
+    arr.truncate(arr.len() - space_count);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,66 +80,58 @@ mod tests {
     #[test]
     fn parse_message_invalid_dest() {
         // Dest must be padded with spaces to 9 characters long
-        let result = r"DEST  :Hello World! This msg has a : colon {32975".parse::<AprsMessage>();
+        let result =
+            AprsMessage::try_from(&b"DEST  :Hello World! This msg has a : colon {32975"[..]);
 
         assert_eq!(
             result,
-            Err(AprsError::InvalidMessageDestination("DEST  ".to_string()))
+            Err(AprsError::InvalidMessageDestination(b"DEST  ".to_vec()))
         );
     }
 
     #[test]
     fn parse_message_id() {
-        let result =
-            r"DESTINATI:Hello World! This msg has a : colon {329A7D5Z4".parse::<AprsMessage>();
+        let result = AprsMessage::try_from(
+            r"DESTINATI:Hello World! This msg has a : colon {329A7D5Z4".as_bytes(),
+        );
 
         assert_eq!(
             result,
             Ok(AprsMessage {
-                addressee: "DESTINATI".to_string(),
-                id: Some("329A7D5Z4".to_string()),
-                text: "Hello World! This msg has a : colon ".to_string()
+                addressee: b"DESTINATI".to_vec(),
+                id: Some(b"329A7D5Z4".to_vec()),
+                text: b"Hello World! This msg has a : colon ".to_vec()
             })
         );
     }
 
     #[test]
     fn parse_message_empty_id() {
-        let result = r"DESTINATI:Hello World! This msg has a : colon {".parse::<AprsMessage>();
+        let result =
+            AprsMessage::try_from(r"DESTINATI:Hello World! This msg has a : colon {".as_bytes());
 
         assert_eq!(
             result,
             Ok(AprsMessage {
-                addressee: "DESTINATI".to_string(),
-                id: Some("".to_string()),
-                text: "Hello World! This msg has a : colon ".to_string()
+                addressee: b"DESTINATI".to_vec(),
+                id: Some(vec![]),
+                text: b"Hello World! This msg has a : colon ".to_vec()
             })
         );
     }
 
     #[test]
     fn parse_message_no_id() {
-        let result = r"DESTINATI:Hello World! This msg has a : colon ".parse::<AprsMessage>();
+        let result =
+            AprsMessage::try_from(r"DESTINATI:Hello World! This msg has a : colon ".as_bytes());
 
         assert_eq!(
             result,
             Ok(AprsMessage {
-                addressee: "DESTINATI".to_string(),
+                addressee: b"DESTINATI".to_vec(),
                 id: None,
-                text: "Hello World! This msg has a : colon ".to_string()
+                text: b"Hello World! This msg has a : colon ".to_vec()
             })
         );
-    }
-}
-
-impl Display for AprsMessage {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, ":{: <9}:{}", self.addressee, self.text)?;
-
-        if let Some(id) = &self.id {
-            write!(f, "{{{}", id)?;
-        }
-
-        Ok(())
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -21,11 +21,11 @@ impl TryFrom<&[u8]> for AprsPosition {
     type Error = AprsError;
 
     fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
-        let first = *b.get(0).ok_or_else(|| AprsError::InvalidPosition(vec![]))? as char;
-        let messaging_supported = first == '=' || first == '@';
+        let first = *b.get(0).ok_or_else(|| AprsError::InvalidPosition(vec![]))?;
+        let messaging_supported = first == b'=' || first == b'@';
 
         // parse timestamp if necessary
-        let has_timestamp = first == '@' || first == '/';
+        let has_timestamp = first == b'@' || first == b'/';
         let timestamp = if has_timestamp {
             Some(Timestamp::try_from(&b[1..8])?)
         } else {
@@ -52,7 +52,7 @@ impl TryFrom<&[u8]> for AprsPosition {
         let symbol_table = b[8] as char;
         let symbol_code = b[18] as char;
 
-        let comment = &b[19..b.len()];
+        let comment = &b[19..];
 
         Ok(AprsPosition {
             timestamp,
@@ -78,7 +78,7 @@ impl AprsPosition {
         write!(buf, "{}", sym)?;
 
         if let Some(ts) = &self.timestamp {
-            write!(buf, "{}", ts)?;
+            ts.encode(buf)?;
         }
 
         write!(


### PR DESCRIPTION
The APRS standard allows packets which are invalid UTF-8. In fact, many packets on the APRS-IS network are not valid UTF-8. This change makes this library follow the standard more closely.

Fixes #45