### PR TITLE
Added parser for status report

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ mod lonlat;
 mod message;
 mod packet;
 mod position;
+mod status;
 mod timestamp;
 
 use std::convert::TryFrom;
@@ -92,6 +93,7 @@ pub use lonlat::{Latitude, Longitude};
 pub use message::AprsMessage;
 pub use packet::{AprsData, AprsPacket};
 pub use position::{AprsCst, AprsPosition};
+pub use status::AprsStatus;
 pub use timestamp::Timestamp;
 
 pub fn parse(b: &[u8]) -> Result<AprsPacket, AprsError> {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use AprsError;
 use AprsMessage;
 use AprsPosition;
+use AprsStatus;
 use Callsign;
 use EncodeError;
 
@@ -74,6 +75,7 @@ impl AprsPacket {
 pub enum AprsData {
     Position(AprsPosition),
     Message(AprsMessage),
+    Status(AprsStatus),
     Unknown,
 }
 
@@ -84,6 +86,7 @@ impl TryFrom<&[u8]> for AprsData {
         Ok(match *s.first().unwrap_or(&0) {
             b':' => AprsData::Message(AprsMessage::try_from(&s[1..])?),
             b'!' | b'/' | b'=' | b'@' => AprsData::Position(AprsPosition::try_from(s)?),
+            b'>' => AprsData::Status(AprsStatus::try_from(&s[1..])?),
             _ => AprsData::Unknown,
         })
     }
@@ -97,6 +100,9 @@ impl AprsData {
             }
             Self::Message(m) => {
                 m.encode(buf)?;
+            }
+            Self::Status(st) => {
+                st.encode(buf)?;
             }
             Self::Unknown => return Err(EncodeError::InvalidData),
         }
@@ -158,6 +164,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_status() {
+        let result =
+            AprsPacket::try_from(&b"ICA3D17F2>APRS,qAS,dl4mea:>312359zStatus seems okay!"[..])
+                .unwrap();
+        assert_eq!(result.from, Callsign::new("ICA3D17F2", None));
+        assert_eq!(result.to, Callsign::new("APRS", None));
+        assert_eq!(
+            result.via,
+            vec![Callsign::new("qAS", None), Callsign::new("dl4mea", None),]
+        );
+
+        match result.data {
+            AprsData::Status(msg) => {
+                assert_eq!(msg.timestamp, Some(Timestamp::DDHHMM(31, 23, 59)));
+                assert_eq!(msg.comment, b"Status seems okay!");
+            }
+            _ => panic!("Unexpected data type"),
+        }
+    }
+
+    #[test]
     fn e2e_serialize_deserialize() {
         let valids = vec![
             r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
@@ -166,6 +193,8 @@ mod tests {
             r"ICA3D17F2>APRS,qAS,dl4mea:=4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {32975",
             r"ICA3D17F2>Aprs,qAS,dl4mea::DESTINATI:Hello World! This msg has a : colon ",
+            r"ICA3D17F2>APRS,qAS,dl4mea:>312359zStatus seems okay!",
+            r"ICA3D17F2>APRS,qAS,dl4mea:>184050hAlso with HMS format...",
         ];
 
         for v in valids {

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,84 @@
+//! A Status Report announces the station's current mission or any other single
+//! line status to everyone. The report starts with the '>' APRS Data Type Identifier.
+//! The report may optionally contain a timestamp.
+//!
+//! Examples:
+//! - ">12.6V 0.2A 22degC"              (report without timestamp)
+//! - ">120503hFatal error"             (report with timestamp in HMS format)
+//! - ">281205zSystem will shutdown"    (report with timestamp in DHM format)
+
+use std::convert::TryFrom;
+use std::io::Write;
+
+use AprsError;
+use EncodeError;
+use Timestamp;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AprsStatus {
+    pub timestamp: Option<Timestamp>,
+    pub comment: Vec<u8>,
+}
+
+impl TryFrom<&[u8]> for AprsStatus {
+    type Error = AprsError;
+
+    fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
+        // Interpret the first 7 bytes as a timestamp, if valid.
+        // Otherwise the whole field is the comment.
+        let timestamp = b.get(..7).and_then(|b| Timestamp::try_from(b).ok());
+        let comment = if timestamp.is_some() { &b[7..] } else { b };
+
+        Ok(AprsStatus {
+            timestamp,
+            comment: comment.to_owned(),
+        })
+    }
+}
+
+impl AprsStatus {
+    pub fn encode<W: Write>(&self, buf: &mut W) -> Result<(), EncodeError> {
+        write!(buf, ">")?;
+
+        if let Some(ts) = &self.timestamp {
+            ts.encode(buf)?;
+        }
+
+        buf.write_all(&self.comment)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_without_timestamp_or_comment() {
+        let result = AprsStatus::try_from(&b""[..]).unwrap();
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.comment, []);
+    }
+
+    #[test]
+    fn parse_with_timestamp_without_comment() {
+        let result = AprsStatus::try_from(r"312359z".as_bytes()).unwrap();
+        assert_eq!(result.timestamp, Some(Timestamp::DDHHMM(31, 23, 59)));
+        assert_eq!(result.comment, b"");
+    }
+
+    #[test]
+    fn parse_without_timestamp_with_comment() {
+        let result = AprsStatus::try_from(&b"Hi there!"[..]).unwrap();
+        assert_eq!(result.timestamp, None);
+        assert_eq!(result.comment, b"Hi there!");
+    }
+
+    #[test]
+    fn parse_with_timestamp_and_comment() {
+        let result = AprsStatus::try_from(r"235959hHi there!".as_bytes()).unwrap();
+        assert_eq!(result.timestamp, Some(Timestamp::HHMMSS(23, 59, 59)));
+        assert_eq!(result.comment, b"Hi there!");
+    }
+}


### PR DESCRIPTION
Deviating from the specification for the timestamp not only the DHM format but also the HMS format is allowed. 