### PR TITLE
Record position precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ fn main() {
     //                 messaging_supported: false
     //                 latitude: Latitude(48.360165),
     //                 longitude: Longitude(12.408166),
+	//                 precision: Precision::HundredthMinute,
     //                 symbol_table: '\\',
     //                 symbol_code: '^',
     //                 comment: "322/103/A=003054"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! extern crate aprs_parser;
 //!
-//! use aprs_parser::{AprsCst, AprsData, AprsPacket, AprsPosition, Callsign, Latitude, Longitude, Timestamp};
+//! use aprs_parser::{AprsCst, AprsData, AprsPacket, AprsPosition, Callsign, Latitude, Longitude, Precision, Timestamp};
 //!
 //! fn main() {
 //!     let result = aprs_parser::parse(
@@ -49,6 +49,7 @@
 //!                         messaging_supported: false,
 //!                         latitude: Latitude::new(48.36016666666667).unwrap(),
 //!                         longitude: Longitude::new(12.408166666666666).unwrap(),
+//!                         precision: Precision::HundredthMinute,
 //!                         symbol_table: '\\',
 //!                         symbol_code: '^',
 //!                         comment: b"322/103/A=003054".to_vec(),
@@ -91,7 +92,7 @@ pub use error::{AprsError, EncodeError};
 pub use lonlat::{Latitude, Longitude};
 pub use message::AprsMessage;
 pub use packet::{AprsData, AprsPacket};
-pub use position::{AprsCst, AprsPosition};
+pub use position::{AprsCst, AprsPosition, Precision};
 pub use timestamp::Timestamp;
 
 pub fn parse(b: &[u8]) -> Result<AprsPacket, AprsError> {

--- a/src/lonlat.rs
+++ b/src/lonlat.rs
@@ -5,6 +5,7 @@ use base91;
 use bytes::parse_bytes;
 use AprsError;
 use EncodeError;
+use Precision;
 
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
 pub struct Latitude(f64);
@@ -19,7 +20,7 @@ impl Deref for Latitude {
 
 impl Latitude {
     /// Creates a new `Latitude`.
-    /// Returns `None` if the given value is not a valid latitude
+    /// Returns `None` if the given value is not a valid latitude.
     pub fn new(value: f64) -> Option<Self> {
         if value > 90.0 || value < -90.0 || value.is_nan() {
             None
@@ -28,7 +29,12 @@ impl Latitude {
         }
     }
 
-    pub(crate) fn parse_uncompressed(b: &[u8]) -> Result<Self, AprsError> {
+    /// The value of the latitude.
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+
+    pub(crate) fn parse_uncompressed(b: &[u8]) -> Result<(Self, Precision), AprsError> {
         if b.len() != 8 || b[4] != b'.' {
             return Err(AprsError::InvalidLatitude(b.to_owned()));
         }
@@ -42,29 +48,42 @@ impl Latitude {
         // Some APRS lats have trailing spaces
         // This is used to convey ambiguity and is only valid in latitudes
         // Once we encounter a space, the remainder must be spaces
-        let (deg, only_spaces) = parse_bytes_trailing_spaces(&[b[0], b[1]], false)
+        let mut total_spaces = 0;
+        let (deg, num_spaces) = parse_bytes_trailing_spaces(&[b[0], b[1]], false)
             .ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))?;
-        let (min, only_spaces) = parse_bytes_trailing_spaces(&[b[2], b[3]], only_spaces)
+        total_spaces += num_spaces;
+        let (min, num_spaces) = parse_bytes_trailing_spaces(&[b[2], b[3]], num_spaces > 0)
             .ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))?;
+        total_spaces += num_spaces;
+        let (min_frac, num_spaces) = parse_bytes_trailing_spaces(&[b[5], b[6]], num_spaces > 0)
+            .ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))?;
+        total_spaces += num_spaces;
 
-        let (min_frac, _) = parse_bytes_trailing_spaces(&[b[5], b[6]], only_spaces)
-            .ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))?;
+        let precision = match total_spaces {
+            0 => Precision::HundredthMinute,
+            1 => Precision::TenthMinute,
+            2 => Precision::OneMinute,
+            3 => Precision::TenMinute,
+            4 => Precision::OneDegree,
+            5 => Precision::TenDegree,
+            6 => return Err(AprsError::InvalidLatitude(b.to_owned())),
+            _ => unreachable!(),
+        };
 
         let value = deg as f64 + min as f64 / 60. + min_frac as f64 / 6_000.;
         let value = if north { value } else { -value };
 
-        Self::new(value).ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))
+        let lat = Self::new(value).ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))?;
+
+        Ok((lat, precision))
     }
 
     pub(crate) fn parse_compressed(b: &[u8]) -> Result<Self, AprsError> {
         let value = 90.0
             - (base91::decode_ascii(b).ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))?
                 / 380926.0);
-        if value > 90. || value < -90. {
-            return Err(AprsError::InvalidLatitude(b.to_owned()));
-        }
 
-        Ok(Self(value))
+        Self::new(value).ok_or_else(|| AprsError::InvalidLatitude(b.to_owned()))
     }
 
     pub(crate) fn encode_compressed<W: Write>(&self, buf: &mut W) -> Result<(), EncodeError> {
@@ -74,10 +93,6 @@ impl Latitude {
 
     pub(crate) fn encode_uncompressed<W: Write>(&self, buf: &mut W) -> Result<(), EncodeError> {
         let lat = self.0;
-
-        if !(-90.0..=90.0).contains(&lat) {
-            return Err(EncodeError::InvalidLatitude(lat));
-        }
 
         let (dir, lat) = if lat >= 0.0 { ('N', lat) } else { ('S', -lat) };
 
@@ -142,11 +157,8 @@ impl Longitude {
             .ok_or_else(|| AprsError::InvalidLongitude(b.to_owned()))?
             / 190463.0)
             - 180.0;
-        if value > 180. || value < -180. {
-            return Err(AprsError::InvalidLongitude(b.to_owned()));
-        }
 
-        Ok(Self(value))
+        Self::new(value).ok_or_else(|| AprsError::InvalidLongitude(b.to_owned()))
     }
 
     pub(crate) fn encode_compressed<W: Write>(&self, buf: &mut W) -> Result<(), EncodeError> {
@@ -156,10 +168,6 @@ impl Longitude {
 
     pub(crate) fn encode_uncompressed<W: Write>(&self, buf: &mut W) -> Result<(), EncodeError> {
         let lon = self.0;
-
-        if !(-180.0..=180.0).contains(&lon) {
-            return Err(EncodeError::InvalidLongitude(lon));
-        }
 
         let (dir, lon) = if lon >= 0.0 { ('E', lon) } else { ('W', -lon) };
 
@@ -173,19 +181,19 @@ impl Longitude {
 }
 
 // if only_spaces is true, requires that b is only spaces
-// returns the parsed value as well as if we found any spaces (used for cascading)
-fn parse_bytes_trailing_spaces(b: &[u8; 2], only_spaces: bool) -> Option<(u32, bool)> {
+// returns the parsed value as well as the number of spaces we found
+fn parse_bytes_trailing_spaces(b: &[u8; 2], only_spaces: bool) -> Option<(u32, u8)> {
     if only_spaces {
         if b == &[b' ', b' '] {
-            return Some((0, true));
+            return Some((0, 2));
         } else {
             return None;
         }
     }
     match (b[0], b[1]) {
-        (b' ', b' ') => Some((0, true)),
-        (_, b' ') => parse_bytes::<u32>(&b[0..1]).map(|v| (v * 10, true)),
-        (_, _) => parse_bytes::<u32>(&b[..]).map(|v| (v, false)),
+        (b' ', b' ') => Some((0, 2)),
+        (_, b' ') => parse_bytes::<u32>(&b[0..1]).map(|v| (v * 10, 1)),
+        (_, _) => parse_bytes::<u32>(&b[..]).map(|v| (v, 0)),
     }
 }
 
@@ -194,48 +202,69 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_latitude_out_of_bounds() {
+        assert_eq!(None, Latitude::new(90.1));
+        assert_eq!(None, Latitude::new(-90.1));
+    }
+
+    #[test]
+    fn test_longitude_out_of_bounds() {
+        assert_eq!(None, Latitude::new(180.1));
+        assert_eq!(None, Latitude::new(-180.1));
+    }
+
+    #[test]
     fn test_parse_bytes_trailing_spaces() {
-        assert_eq!(Some((12, false)), parse_bytes_trailing_spaces(b"12", false));
-        assert_eq!(Some((10, true)), parse_bytes_trailing_spaces(b"1 ", false));
-        assert_eq!(Some((0, true)), parse_bytes_trailing_spaces(b"  ", false));
+        assert_eq!(Some((12, 0)), parse_bytes_trailing_spaces(b"12", false));
+        assert_eq!(Some((10, 1)), parse_bytes_trailing_spaces(b"1 ", false));
+        assert_eq!(Some((0, 2)), parse_bytes_trailing_spaces(b"  ", false));
 
         assert_eq!(None, parse_bytes_trailing_spaces(b" 2", false));
 
         assert_eq!(None, parse_bytes_trailing_spaces(b"12", true));
         assert_eq!(None, parse_bytes_trailing_spaces(b"1 ", true));
         assert_eq!(None, parse_bytes_trailing_spaces(b" 1", true));
-        assert_eq!(Some((0, true)), parse_bytes_trailing_spaces(b"  ", true));
+        assert_eq!(Some((0, 2)), parse_bytes_trailing_spaces(b"  ", true));
     }
 
     #[test]
     fn test_parse_uncompressed_latitude() {
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"4903.50N"[..]).unwrap(),
-            49.05833333333333
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"4903.50N"[..]).unwrap(),
+            (
+                Latitude::new(49.05833333333333).unwrap(),
+                Precision::HundredthMinute
+            )
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"4903.50S"[..]).unwrap(),
-            -49.05833333333333
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"4903.50S"[..]).unwrap(),
+            (
+                Latitude::new(-49.05833333333333).unwrap(),
+                Precision::HundredthMinute
+            )
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"4903.5 S"[..]).unwrap(),
-            -49.05833333333333
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"4903.5 S"[..]).unwrap(),
+            (
+                Latitude::new(-49.05833333333333).unwrap(),
+                Precision::TenthMinute
+            )
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"4903.  S"[..]).unwrap(),
-            -49.05
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"4903.  S"[..]).unwrap(),
+            (Latitude::new(-49.05).unwrap(), Precision::OneMinute)
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"490 .  S"[..]).unwrap(),
-            -49.0
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"490 .  S"[..]).unwrap(),
+            (Latitude::new(-49.0).unwrap(), Precision::TenMinute)
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"4   .  S"[..]).unwrap(),
-            -40.0
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"4   .  S"[..]).unwrap(),
+            (Latitude::new(-40.0).unwrap(), Precision::TenDegree)
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"    .  S"[..]).unwrap(),
-            0.0
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"    .  S"[..]),
+            Err(AprsError::InvalidLatitude(b"    .  S".to_vec()))
         );
         assert_eq!(
             Latitude::parse_uncompressed(&b"49 3.50W"[..]),
@@ -261,13 +290,13 @@ mod tests {
             Latitude::parse_uncompressed(&b"9903.50N"[..]),
             Err(AprsError::InvalidLatitude(b"9903.50N".to_vec()))
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"0000.00N"[..]).unwrap(),
-            0.0
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"0000.00N"[..]).unwrap(),
+            (Latitude::new(0.0).unwrap(), Precision::HundredthMinute)
         );
-        assert_relative_eq!(
-            *Latitude::parse_uncompressed(&b"0000.00S"[..]).unwrap(),
-            0.0
+        assert_eq!(
+            Latitude::parse_uncompressed(&b"0000.00S"[..]).unwrap(),
+            (Latitude::new(0.0).unwrap(), Precision::HundredthMinute)
         );
     }
 
@@ -306,47 +335,42 @@ mod tests {
     #[test]
     fn test_encode_uncompressed_latitude() {
         let mut buf = vec![];
-        Latitude(49.05833).encode_uncompressed(&mut buf).unwrap();
+        Latitude::new(49.05833)
+            .unwrap()
+            .encode_uncompressed(&mut buf)
+            .unwrap();
         assert_eq!(buf, &b"4903.50N"[..]);
 
         let mut buf = vec![];
-        Latitude(-49.05833).encode_uncompressed(&mut buf).unwrap();
+        Latitude::new(-49.05833)
+            .unwrap()
+            .encode_uncompressed(&mut buf)
+            .unwrap();
         assert_eq!(buf, &b"4903.50S"[..]);
 
         let mut buf = vec![];
-        assert!(matches!(
-            Latitude(-90.1).encode_uncompressed(&mut buf),
-            Err(EncodeError::InvalidLatitude(x)) if x == -90.1
-        ));
-        assert!(matches!(
-            Latitude(90.1).encode_uncompressed(&mut buf),
-            Err(EncodeError::InvalidLatitude(x)) if x == 90.1
-        ));
-
-        let mut buf = vec![];
-        Latitude(0.0).encode_uncompressed(&mut buf).unwrap();
+        Latitude::new(0.0)
+            .unwrap()
+            .encode_uncompressed(&mut buf)
+            .unwrap();
         assert_eq!(buf, &b"0000.00N"[..]);
     }
 
     #[test]
     fn test_encode_uncompressed_longitude() {
         let mut buf = vec![];
-        Longitude(129.05833).encode_uncompressed(&mut buf).unwrap();
+        Longitude::new(129.05833)
+            .unwrap()
+            .encode_uncompressed(&mut buf)
+            .unwrap();
         assert_eq!(buf, &b"12903.50E"[..]);
 
         let mut buf = vec![];
-        Longitude(-49.0583).encode_uncompressed(&mut buf).unwrap();
+        Longitude::new(-49.0583)
+            .unwrap()
+            .encode_uncompressed(&mut buf)
+            .unwrap();
         assert_eq!(buf, &b"04903.50W"[..]);
-
-        let mut buf = vec![];
-        assert!(matches!(
-            Longitude(-180.1).encode_uncompressed(&mut buf),
-            Err(EncodeError::InvalidLongitude(x)) if x == -180.1
-        ));
-        assert!(matches!(
-            Longitude(180.1).encode_uncompressed(&mut buf),
-            Err(EncodeError::InvalidLongitude(x)) if x == 180.1
-        ));
 
         let mut buf = vec![];
         Longitude(0.0).encode_uncompressed(&mut buf).unwrap();

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -108,7 +108,6 @@ impl AprsData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use Latitude;
     use Timestamp;
 
     #[test]
@@ -124,8 +123,8 @@ mod tests {
         match result.data {
             AprsData::Position(position) => {
                 assert_eq!(position.timestamp, Some(Timestamp::HHMMSS(7, 48, 49)));
-                assert_eq!(position.latitude, Latitude::new(48.36016666666667).unwrap());
-                assert_relative_eq!(*position.longitude, 12.408166666666666);
+                assert_eq!(position.latitude.value(), 48.36016666666667);
+                assert_eq!(position.longitude.value(), 12.408166666666666);
                 assert_eq!(
                     position.comment,
                     b"322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1"
@@ -164,7 +163,7 @@ mod tests {
             r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>APRS,qAS,dl4mea:@074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>APRS,qAS,dl4mea:!4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
-            r"ICA3D17F2>APRS,qAS,dl4mea:!48  .  N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
+            r"ICA3D17F2>APRS,qAS,dl4mea:!48  .  N\01200.00E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>APRS,qAS,dl4mea:=4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {32975",
             r"ICA3D17F2>Aprs,qAS,dl4mea::DESTINATI:Hello World! This msg has a : colon ",

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -108,6 +108,7 @@ impl AprsData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use Latitude;
     use Timestamp;
 
     #[test]
@@ -123,7 +124,7 @@ mod tests {
         match result.data {
             AprsData::Position(position) => {
                 assert_eq!(position.timestamp, Some(Timestamp::HHMMSS(7, 48, 49)));
-                assert_relative_eq!(*position.latitude, 48.36016666666667);
+                assert_eq!(position.latitude, Latitude::new(48.36016666666667).unwrap());
                 assert_relative_eq!(*position.longitude, 12.408166666666666);
                 assert_eq!(
                     position.comment,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -164,6 +164,7 @@ mod tests {
             r"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>APRS,qAS,dl4mea:@074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>APRS,qAS,dl4mea:!4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
+            r"ICA3D17F2>APRS,qAS,dl4mea:!48  .  N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>APRS,qAS,dl4mea:=4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",
             r"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {32975",
             r"ICA3D17F2>Aprs,qAS,dl4mea::DESTINATI:Hello World! This msg has a : colon ",

--- a/src/position.rs
+++ b/src/position.rs
@@ -168,7 +168,7 @@ impl AprsPosition {
 
         // parse position
         let (latitude, precision) = Latitude::parse_uncompressed(&b[0..8])?;
-        let longitude = Longitude::parse_uncompressed(&b[9..18])?;
+        let longitude = Longitude::parse_uncompressed(&b[9..18], precision)?;
 
         let symbol_table = b[8] as char;
         let symbol_code = b[18] as char;
@@ -410,11 +410,11 @@ mod tests {
     fn parse_with_comment() {
         let result = AprsPosition::try_from(&b"!4903.5 N/07201.75W-Hello/A=001000"[..]).unwrap();
         assert_eq!(result.timestamp, None);
-        assert_relative_eq!(*result.latitude, 49.05833333333333);
-        assert_relative_eq!(*result.longitude, -72.02916666666667);
+        assert_eq!(*result.latitude, 49.05833333333333);
+        assert_eq!(*result.longitude, -72.02833333333334);
         assert_eq!(Precision::TenthMinute, result.precision);
         assert_eq!(49.0575..=49.05916666666666, result.latitude_bounding());
-        assert_eq!(-72.03..=-72.02833333333334, result.longitude_bounding());
+        assert_eq!(-72.02916666666667..=-72.0275, result.longitude_bounding());
         assert_eq!(result.symbol_table, '/');
         assert_eq!(result.symbol_code, '-');
         assert_eq!(result.comment, b"Hello/A=001000");
@@ -475,7 +475,7 @@ mod tests {
             &br"/074849h4821.61N\01224.49E^322/103/A=003054"[..],
             &b"=4903.50N/07201.75W-"[..],
             &br"@074849h4821.61N\01224.49E^322/103/A=003054"[..],
-            &br"@074849h4821.  N\01224.49E^322/103/A=003054"[..],
+            &br"@074849h4821.  N\01224.00E^322/103/A=003054"[..],
         ];
 
         for p in positions {


### PR DESCRIPTION
I started working on Mic-E encoding/decoding and realized it also deals with position precision. I figured it makes sense to add this now so that we can work with it in Mic-E.

@Turbo87 Tagging you as you requested this. Works in both directions (encoding and decoding)