### PR TITLE
Add ax.25 encoding/decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.52.0  # minimum supported version
+          - 1.60.0  # minimum supported version
           - stable
 
     steps:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup default 1.57.0
+      - run: rustup default 1.67.1
       - run: rustup component add rustfmt
       - run: cargo fmt -- --check
 
@@ -41,6 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup default 1.57.0
+      - run: rustup default 1.67.1
       - run: rustup component add clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/Turbo87/aprs-parser-rs/"
 repository = "https://github.com/Turbo87/aprs-parser-rs.git"
 license = "MIT/Apache-2.0"
 exclude = [".gitignore", ".travis.yml"]
-rust-version = "1.52.0"
+rust-version = "1.60.0"
 
 [dependencies]
 thiserror = "1.0.38"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ aprs-parser
 [APRS]: http://www.aprs.org/
 [Rust]: https://www.rust-lang.org/
 
+Features
+--------------------------------------
+- Supports packet encoding and decoding
+- Supports textual representations (APRS-IS) as well as binary/AX.25 representations (KISS)
 
 Usage
 ------------------------------------------------------------------------------
@@ -18,7 +22,7 @@ extern crate aprs_parser;
 
 fn main() {
     let result = aprs_parser::parse(
-        br"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
+        br"ICA3D2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
     );
 
     println!("{:#?}", result);
@@ -26,22 +30,29 @@ fn main() {
     // Ok(
     //     AprsPacket {
     //         from: Callsign {
-    //             call: "ICA3D17F2",
-    //             ssid: None
+    //             call: "IC17F2"
+    //             ssid: None,
     //         },
     //         to: Callsign {
-    //             call: "APRS",
-    //             ssid: None
+    //             call: [
+    //                 65,
+    //                 80,
+    //                 82,
+    //                 83,
+    //             ],
+    //             ssid: None,
     //         },
     //         via: [
-    //             Callsign {
-    //                 call: "qAS",
-    //                 ssid: None
-    //             },
-    //             Callsign {
-    //                 call: "dl4mea",
-    //                 ssid: None
-    //             }
+    //             QConstruct(
+    //                 AS,
+    //             ),
+    //             Callsign(
+    //                 Callsign {
+    //                     call: "dl4mea"
+    //                     ssid: None,
+    //                 },
+    //                 false,
+    //             ),
     //         ],
     //         data: Position(
     //             AprsPosition {
@@ -49,19 +60,41 @@ fn main() {
     //                     HHMMSS(
     //                         7,
     //                         48,
-    //                         49
-    //                     )
+    //                         49,
+    //                     ),
     //                 ),
-    //                 messaging_supported: false
-    //                 latitude: Latitude(48.360165),
-    //                 longitude: Longitude(12.408166),
-    //                 precision: Precision::HundredthMinute,
+    //                 messaging_supported: false,
+    //                 latitude: Latitude(
+    //                     48.36016666666667,
+    //                 ),
+    //                 longitude: Longitude(
+    //                     12.408166666666666,
+    //                 ),
+    //                 precision: HundredthMinute,
     //                 symbol_table: '\\',
     //                 symbol_code: '^',
-    //                 comment: "322/103/A=003054"
-    //             }
-    //         )
-    //     }
+    //                 comment: [
+    //                     51,
+    //                     50,
+    //                     50,
+    //                     47,
+    //                     49,
+    //                     48,
+    //                     51,
+    //                     47,
+    //                     65,
+    //                     61,
+    //                     48,
+    //                     48,
+    //                     51,
+    //                     48,
+    //                     53,
+    //                     52,
+    //                 ],
+    //                 cst: Uncompressed,
+    //             },
+    //         ),
+    //     },
     // )
 }
 ```

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,8 +1,10 @@
+use aprs_parser::AprsPacket;
+
 extern crate aprs_parser;
 
 fn main() {
-    let result = aprs_parser::parse(
-        br"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054",
+    let result = AprsPacket::decode_textual(
+        br"IC17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054",
     );
 
     println!("{:#?}", result);

--- a/src/callsign.rs
+++ b/src/callsign.rs
@@ -1,42 +1,175 @@
-use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
+use std::io::{self, Write};
 
-use AprsError;
+use EncodeError;
+
+pub enum CallsignField {
+    Destination,
+    Source,
+    Via(bool),
+}
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct Callsign {
-    pub call: String,
-    pub ssid: Option<String>,
+    call: String,
+    ssid: Option<String>,
 }
 
 impl Callsign {
-    pub fn new<T: Into<String>>(call: T, ssid: Option<T>) -> Callsign {
-        Callsign {
-            call: call.into(),
-            ssid: ssid.map(|ssid| ssid.into()),
-        }
-    }
-}
-
-impl TryFrom<&[u8]> for Callsign {
-    type Error = AprsError;
-
-    fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
-        let s = std::str::from_utf8(b).map_err(|_| AprsError::NonUtf8Callsign(b.to_owned()))?;
-
-        match s.split_once('-') {
+    /// Create a new callsign.
+    /// SSID is parsed out.
+    pub fn new(s: impl AsRef<str>) -> Option<Self> {
+        match s.as_ref().split_once('-') {
             Some((call, ssid)) => {
-                if call.is_empty() {
-                    Err(AprsError::EmptyCallsign(s.to_owned()))
-                } else if ssid.is_empty() {
-                    Err(AprsError::EmptySSID(s.to_owned()))
+                if call.is_empty() || ssid.is_empty() {
+                    None
                 } else {
-                    Ok(Callsign::new(call, Some(ssid)))
+                    Some(Callsign::new_with_ssid(call.to_owned(), ssid))
                 }
             }
 
-            None => Ok(Callsign::new(s, None)),
+            None => Some(Callsign::new_no_ssid(s.as_ref())),
         }
+    }
+
+    /// Create a new callsign
+    /// Note: If you need a callsign with an SSID, use `new_with_ssid`.
+    pub fn new_no_ssid(call: impl Into<String>) -> Callsign {
+        let call = call.into();
+        let ssid = None;
+        Callsign { call, ssid }
+    }
+
+    pub fn new_with_ssid(call: impl Into<String>, ssid: impl Into<String>) -> Callsign {
+        let call = call.into();
+        let ssid = Some(ssid.into());
+        Callsign { call, ssid }
+    }
+
+    pub fn encode_textual<W: Write>(&self, heard: bool, w: &mut W) -> io::Result<()> {
+        write!(w, "{}", self)?;
+
+        if heard {
+            write!(w, "*")?;
+        }
+
+        Ok(())
+    }
+
+    pub fn decode_textual(bytes: &[u8]) -> Option<(Self, bool)> {
+        let (bytes, heard) = if bytes.last() == Some(&b'*') {
+            (&bytes[0..(bytes.len() - 1)], true)
+        } else {
+            (bytes, false)
+        };
+
+        let s = std::str::from_utf8(bytes).ok()?;
+
+        Self::new(s).map(|c| (c, heard))
+    }
+
+    pub fn encode_ax25<W: Write>(
+        &self,
+        buf: &mut W,
+        field: CallsignField,
+        has_more: bool,
+    ) -> Result<(), EncodeError> {
+        // callsign requirements:
+        // <= 6 bytes long
+        // all alphanumeric uppercase
+        // ssid missing or a number between 0 and 15
+
+        let call = self.call.as_bytes();
+        if call.len() > 6 {
+            return Err(EncodeError::InvalidCallsign(self.clone()));
+        }
+
+        let ssid: u8 = self
+            .ssid
+            .clone()
+            .map(|x| x.parse().ok())
+            .unwrap_or(Some(0))
+            .ok_or_else(|| EncodeError::InvalidCallsign(self.clone()))?;
+
+        if ssid > 15 {
+            return Err(EncodeError::InvalidCallsign(self.clone()));
+        }
+
+        let has_more = if has_more { 0 } else { 1 };
+
+        for c in call {
+            if !c.is_ascii_alphanumeric() {
+                return Err(EncodeError::InvalidCallsign(self.clone()));
+            }
+
+            buf.write_all(&[c.to_ascii_uppercase() << 1])?;
+        }
+
+        for _ in call.len()..6 {
+            buf.write_all(&[b' ' << 1])?;
+        }
+
+        match field {
+            CallsignField::Destination => {
+                buf.write_all(&[0b11100000 | (ssid << 1) | has_more])?;
+            }
+            CallsignField::Source => {
+                buf.write_all(&[0b01100000 | (ssid << 1) | has_more])?;
+            }
+            CallsignField::Via(heard) => {
+                let heard = if heard { 1 } else { 0 };
+
+                buf.write_all(&[0b01100000 | (ssid << 1) | (heard << 7) | has_more])?;
+            }
+        }
+
+        Ok(())
+    }
+
+    // Returns self, heard, and the flag for if there's another callsign after
+    pub fn decode_ax25(data: &[u8]) -> Option<(Self, bool, bool)> {
+        if data.len() != 7 {
+            return None;
+        }
+
+        let mut call = String::new();
+        let mut found_space = false;
+        for d in &data[0..6] {
+            // LSB must be cleared
+            if (d & 0x01) != 0 {
+                return None;
+            }
+            let d = d >> 1;
+
+            if d == b' ' {
+                found_space = true;
+                continue;
+            }
+
+            // non-space char after a space
+            if found_space {
+                return None;
+            }
+
+            if !d.is_ascii_alphanumeric() {
+                return None;
+            }
+
+            call.push(d.to_ascii_uppercase().into());
+        }
+
+        let s = data[6];
+        let heard = (s & 0x80) != 0;
+        let has_more = (s & 0x01) == 0;
+        let ssid = (s & 0x1E) >> 1;
+
+        let ssid = if ssid == 0 {
+            None
+        } else {
+            Some(format!("{}", ssid))
+        };
+
+        Some((Callsign { call, ssid }, heard, has_more))
     }
 }
 
@@ -45,7 +178,9 @@ impl Display for Callsign {
         write!(f, "{}", self.call)?;
 
         if let Some(ssid) = &self.ssid {
-            write!(f, "-{}", ssid)?;
+            if !ssid.is_empty() {
+                write!(f, "-{}", ssid)?;
+            }
         }
 
         Ok(())
@@ -55,58 +190,164 @@ impl Display for Callsign {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryInto;
 
     #[test]
     fn parse_callsign() {
         assert_eq!(
-            "ABCDEF".as_bytes().try_into(),
-            Ok(Callsign::new("ABCDEF", None))
+            Callsign::decode_textual(&b"ABCDEF"[..]),
+            Some((Callsign::new("ABCDEF").unwrap(), false))
+        );
+    }
+
+    #[test]
+    fn parse_heard_callsign() {
+        assert_eq!(
+            Callsign::decode_textual(&b"ABCDEF*"[..]),
+            Some((Callsign::new("ABCDEF").unwrap(), true))
         );
     }
 
     #[test]
     fn parse_with_ssid() {
         assert_eq!(
-            "ABCDEF-42".as_bytes().try_into(),
-            Ok(Callsign::new("ABCDEF", Some("42")))
+            Callsign::decode_textual(&b"ABCDEF-2"[..]),
+            Some((Callsign::new_with_ssid("ABCDEF", "2"), false))
         );
+    }
+
+    #[test]
+    fn omit_end_spaces() {
+        assert_eq!(
+            Callsign::decode_ax25(&[172, 138, 114, 64, 64, 64, 1]),
+            Some((Callsign::new_no_ssid("VE9"), false, false))
+        )
+    }
+
+    #[test]
+    fn spaces_in_middle() {
+        assert_eq!(Callsign::decode_ax25(&[172, 64, 114, 64, 64, 64, 1]), None)
+    }
+
+    #[test]
+    fn uppercase_callsign() {
+        assert_eq!(
+            Callsign::decode_ax25(&[236, 202, 114, 64, 64, 64, 1]),
+            Some((Callsign::new_no_ssid("VE9"), false, false))
+        );
+
+        let mut buf = vec![];
+        let c = Callsign::new_no_ssid("ve9");
+        c.encode_ax25(&mut buf, CallsignField::Destination, false)
+            .unwrap();
+        assert_eq!(&[172, 138, 114, 64, 64, 64, 225][..], buf);
+
+        // sanity check with callsign that's already uppercased
+        let mut buf = vec![];
+        let c = Callsign::new_no_ssid("VE9");
+        c.encode_ax25(&mut buf, CallsignField::Destination, false)
+            .unwrap();
+        assert_eq!(&[172, 138, 114, 64, 64, 64, 225][..], buf);
+    }
+
+    #[test]
+    fn non_alphanumeric() {
+        let mut buf = vec![];
+        assert!(matches!(
+        Callsign::new_no_ssid("VE9---").encode_ax25(
+            &mut buf,
+            CallsignField::Destination,
+            false
+        ),
+        Err(EncodeError::InvalidCallsign(c)) if c == Callsign::new_no_ssid(
+            "VE9---"
+        )));
+    }
+
+    #[test]
+    fn callsign_too_long() {
+        let mut buf = vec![];
+        assert!(matches!(
+            Callsign::new_no_ssid("VE9ABCD").encode_ax25(
+                &mut buf,
+                CallsignField::Source,
+                false
+            ),
+            Err(EncodeError::InvalidCallsign(c)) if c == Callsign::new_no_ssid(
+                "VE9ABCD"
+            )
+        ));
     }
 
     #[test]
     fn empty_callsign() {
-        assert_eq!(
-            Callsign::try_from("-42".as_bytes()),
-            Err(AprsError::EmptyCallsign("-42".to_owned()))
-        );
+        assert_eq!(Callsign::decode_textual("-3".as_bytes()), None);
     }
 
     #[test]
     fn empty_ssid() {
-        assert_eq!(
-            Callsign::try_from("ABCDEF-".as_bytes()),
-            Err(AprsError::EmptySSID("ABCDEF-".to_owned()))
-        );
+        assert_eq!(Callsign::decode_textual("ABCDEF-".as_bytes()), None);
     }
 
     #[test]
     fn non_utf8() {
-        assert_eq!(
-            Callsign::try_from(&b"ABCDEF\xF0\xA4\xAD"[..]),
-            Err(AprsError::NonUtf8Callsign(b"ABCDEF\xF0\xA4\xAD".to_vec()))
-        );
+        assert_eq!(Callsign::decode_textual(&b"ABCDEF\xF0\xA4\xAD"[..]), None);
+    }
+
+    #[test]
+    fn textual_no_ssid() {
+        let c = Callsign::new_no_ssid("ABCDEF");
+
+        assert_eq!("ABCDEF", format!("{}", c));
+
+        let mut buf = vec![];
+        c.encode_textual(true, &mut buf).unwrap();
+        assert_eq!(&b"ABCDEF*"[..], buf);
+
+        buf.clear();
+        c.encode_textual(false, &mut buf).unwrap();
+        assert_eq!(&b"ABCDEF"[..], buf);
+    }
+
+    #[test]
+    fn textual_with_ssid() {
+        let c = Callsign::new_with_ssid("ABCDEF", "XF");
+
+        assert_eq!("ABCDEF-XF", format!("{}", c));
+
+        let mut buf = vec![];
+        c.encode_textual(true, &mut buf).unwrap();
+        assert_eq!(&b"ABCDEF-XF*"[..], buf);
+
+        buf.clear();
+        c.encode_textual(false, &mut buf).unwrap();
+        assert_eq!(&b"ABCDEF-XF"[..], buf);
+    }
+
+    #[test]
+    fn textual_non_ascii_characters() {
+        let c = Callsign::new_with_ssid("ABCDEF\x001\x002", "XF\x002\x003");
+
+        assert_eq!("ABCDEF\x001\x002-XF\x002\x003", format!("{}", c));
+
+        let mut buf = vec![];
+        c.encode_textual(true, &mut buf).unwrap();
+        assert_eq!(&b"ABCDEF\x001\x002-XF\x002\x003*"[..], buf);
+
+        buf.clear();
+        c.encode_textual(false, &mut buf).unwrap();
+        assert_eq!(&b"ABCDEF\x001\x002-XF\x002\x003"[..], buf);
     }
 
     #[test]
     fn display_no_ssid() {
-        assert_eq!("ABCDEF", format!("{}", Callsign::new("ABCDEF", None)));
+        assert_eq!("ABCDEF", format!("{}", Callsign::new_no_ssid("ABCDEF")));
     }
 
     #[test]
     fn display_with_ssid() {
         assert_eq!(
             "ABCDEF-12",
-            format!("{}", Callsign::new("ABCDEF", Some("12")))
+            format!("{}", Callsign::new_with_ssid("ABCDEF", "12"))
         );
     }
 }

--- a/src/compressed_cs.rs
+++ b/src/compressed_cs.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use base91;
 use compression_type::NmeaSource;
 use AprsCompressionType;
-use AprsError;
+use DecodeError;
 use EncodeError;
 
 #[derive(PartialEq, Copy, Clone, Debug)]
@@ -14,9 +14,9 @@ pub enum AprsCompressedCs {
 }
 
 impl AprsCompressedCs {
-    pub(crate) fn parse(c: u8, s: u8, t: AprsCompressionType) -> Result<Self, AprsError> {
-        let c_lwr = base91::digit_from_ascii(c).ok_or(AprsError::InvalidCs([c, s]))?;
-        let s_lwr = base91::digit_from_ascii(s).ok_or(AprsError::InvalidCs([c, s]))?;
+    pub(crate) fn parse(c: u8, s: u8, t: AprsCompressionType) -> Result<Self, DecodeError> {
+        let c_lwr = base91::digit_from_ascii(c).ok_or(DecodeError::InvalidCs([c, s]))?;
+        let s_lwr = base91::digit_from_ascii(s).ok_or(DecodeError::InvalidCs([c, s]))?;
 
         if t.nmea_source == NmeaSource::Gga {
             Ok(AprsCompressedCs::Altitude(AprsAltitude::from_cs(
@@ -26,7 +26,7 @@ impl AprsCompressedCs {
             let val = match c_lwr {
                 0..=89 => AprsCompressedCs::CourseSpeed(AprsCourseSpeed::from_cs(c_lwr, s_lwr)),
                 90 => AprsCompressedCs::RadioRange(AprsRadioRange::from_s(s_lwr)),
-                _ => return Err(AprsError::InvalidCs([c, s])),
+                _ => return Err(DecodeError::InvalidCs([c, s])),
             };
 
             Ok(val)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,11 @@
+use Callsign;
+
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
-pub enum AprsError {
-    #[error("Non-UTF8 Callsign: {0:?}")]
-    NonUtf8Callsign(Vec<u8>),
-    #[error("Empty Callsign: {0:?}")]
-    EmptyCallsign(String),
-    #[error("Empty Callsign SSID: {0:?}")]
-    EmptySSID(String),
+pub enum DecodeError {
+    #[error("Invalid Callsign: {0:?}")]
+    InvalidCallsign(Vec<u8>),
+    #[error("Invalid Via: {0:?}")]
+    InvalidVia(Vec<u8>),
     #[error("Invalid Timestamp: {0:?}")]
     InvalidTimestamp(Vec<u8>),
     #[error("Unsupported Position Format: {0:?}")]
@@ -28,6 +28,8 @@ pub enum AprsError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum EncodeError {
+    #[error("Callsign can't be encoded: {0:?}")]
+    InvalidCallsign(Callsign),
     #[error("Invalid Latitude: {0}")]
     InvalidLatitude(f64),
     #[error("Invalid Longitude: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,34 +8,22 @@
 //! ```rust
 //! extern crate aprs_parser;
 //!
-//! use aprs_parser::{AprsCst, AprsData, AprsPacket, AprsPosition, Callsign, Latitude, Longitude, Precision, Timestamp};
+//! use aprs_parser::{AprsCst, AprsData, AprsPacket, AprsPosition, Callsign, Latitude, Longitude, Precision, Timestamp, Via, QConstruct};
 //!
 //! fn main() {
-//!     let result = aprs_parser::parse(
-//!         br"ICA3D17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
+//!     let result = AprsPacket::decode_textual(
+//!         br"ICA3D2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"
 //!     );
 //!
 //!     assert_eq!(
 //!         result,
 //!         Ok(
 //!             AprsPacket {
-//!                 from: Callsign {
-//!                     call: "ICA3D17F2".to_string(),
-//!                     ssid: None
-//!                 },
-//!                 to: Callsign {
-//!                     call: "APRS".to_string(),
-//!                     ssid: None
-//!                 },
+//!                 from: Callsign::new_no_ssid("ICA3D2"),
+//!                 to: Callsign::new_no_ssid("APRS"),
 //!                 via: vec![
-//!                     Callsign {
-//!                         call: "qAS".to_string(),
-//!                         ssid: None
-//!                     },
-//!                     Callsign {
-//!                         call: "dl4mea".to_string(),
-//!                         ssid: None
-//!                     }
+//!                     Via::QConstruct(QConstruct::AS),
+//!                     Via::Callsign(Callsign::new_no_ssid("dl4mea"), false),
 //!                 ],
 //!                 data: AprsData::Position(
 //!                     AprsPosition {
@@ -83,23 +71,19 @@ mod packet;
 mod position;
 mod status;
 mod timestamp;
-
-use std::convert::TryFrom;
+mod via;
 
 pub use callsign::Callsign;
 pub use compressed_cs::{AprsAltitude, AprsCompressedCs, AprsCourseSpeed, AprsRadioRange};
 pub use compression_type::AprsCompressionType;
-pub use error::{AprsError, EncodeError};
+pub use error::{DecodeError, EncodeError};
 pub use lonlat::{Latitude, Longitude};
 pub use message::AprsMessage;
 pub use packet::{AprsData, AprsPacket};
 pub use position::{AprsCst, AprsPosition, Precision};
 pub use status::AprsStatus;
 pub use timestamp::{DhmTimestamp, Timestamp};
-
-pub fn parse(b: &[u8]) -> Result<AprsPacket, AprsError> {
-    AprsPacket::try_from(b)
-}
+pub use via::{QConstruct, Via};
 
 #[cfg(test)]
 mod tests {
@@ -108,10 +92,13 @@ mod tests {
     #[test]
     fn overall() {
         let original =
-            &b"ICA3D17F2>Aprs,qAS,dl4mea::DEST     :Hello World! This msg has a : colon {3a2B975"[..];
+            &b"ICA3D2>Aprs,qAO,dl4mea::DEST     :Hello World! This msg has a : colon {3a2B975"[..];
 
         let mut buf = vec![];
-        parse(original).unwrap().encode(&mut buf).unwrap();
+        AprsPacket::decode_textual(original)
+            .unwrap()
+            .encode_textual(&mut buf)
+            .unwrap();
         assert_eq!(original, &buf);
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::io::Write;
 
-use AprsError;
+use DecodeError;
 use EncodeError;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -38,20 +38,20 @@ impl AprsMessage {
 }
 
 impl TryFrom<&[u8]> for AprsMessage {
-    type Error = AprsError;
+    type Error = DecodeError;
 
-    fn try_from(b: &[u8]) -> Result<Self, AprsError> {
+    fn try_from(b: &[u8]) -> Result<Self, DecodeError> {
         let mut splitter = b.splitn(2, |x| *x == b':');
 
         let mut addressee = match splitter.next() {
             Some(x) => x.to_vec(),
             None => {
-                return Err(AprsError::InvalidMessageDestination(vec![]));
+                return Err(DecodeError::InvalidMessageDestination(vec![]));
             }
         };
 
         if addressee.len() != 9 {
-            return Err(AprsError::InvalidMessageDestination(addressee.to_owned()));
+            return Err(DecodeError::InvalidMessageDestination(addressee.to_owned()));
         }
 
         trim_spaces_end(&mut addressee);
@@ -87,7 +87,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(AprsError::InvalidMessageDestination(b"DEST  ".to_vec()))
+            Err(DecodeError::InvalidMessageDestination(b"DEST  ".to_vec()))
         );
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -10,7 +10,7 @@
 use std::convert::TryFrom;
 use std::io::Write;
 
-use AprsError;
+use DecodeError;
 use DhmTimestamp;
 use EncodeError;
 use Timestamp;
@@ -63,7 +63,7 @@ impl AprsStatus {
 }
 
 impl TryFrom<&[u8]> for AprsStatus {
-    type Error = AprsError;
+    type Error = DecodeError;
 
     fn try_from(b: &[u8]) -> Result<Self, Self::Error> {
         // Interpret the first 7 bytes as a timestamp, if valid.

--- a/src/via.rs
+++ b/src/via.rs
@@ -1,0 +1,101 @@
+use std::io::{self, Write};
+
+use Callsign;
+
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub enum Via {
+    Callsign(Callsign, bool),
+    QConstruct(QConstruct),
+}
+
+impl Via {
+    pub fn decode_textual(bytes: &[u8]) -> Option<Self> {
+        if let Some(q) = QConstruct::decode_textual(bytes) {
+            return Some(Self::QConstruct(q));
+        }
+
+        if let Some((c, heard)) = Callsign::decode_textual(bytes) {
+            return Some(Self::Callsign(c, heard));
+        }
+
+        None
+    }
+
+    pub fn encode_textual<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        match self {
+            Self::Callsign(c, heard) => {
+                c.encode_textual(*heard, w)?;
+            }
+            Self::QConstruct(q) => {
+                write!(w, "{}", q.as_textual())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn callsign(&self) -> Option<(&Callsign, bool)> {
+        match self {
+            Self::Callsign(c, heard) => Some((c, *heard)),
+            Self::QConstruct(_) => None,
+        }
+    }
+
+    pub fn callsign_mut(&mut self) -> Option<(&mut Callsign, &mut bool)> {
+        match self {
+            Self::Callsign(c, heard) => Some((c, heard)),
+            Self::QConstruct(_) => None,
+        }
+    }
+}
+
+// Can't be encoded/decoded as ax.25
+// These should never go on the air
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum QConstruct {
+    AC,
+    AX,
+    AU,
+    Ao,
+    AO,
+    AS,
+    Ar,
+    AR,
+    AZ,
+    AI,
+}
+
+impl QConstruct {
+    pub fn decode_textual(bytes: &[u8]) -> Option<Self> {
+        let q = match bytes {
+            b"qAC" => QConstruct::AC,
+            b"qAX" => QConstruct::AX,
+            b"qAU" => QConstruct::AU,
+            b"qAo" => QConstruct::Ao,
+            b"qAO" => QConstruct::AO,
+            b"qAS" => QConstruct::AS,
+            b"qAr" => QConstruct::Ar,
+            b"qAR" => QConstruct::AR,
+            b"qAZ" => QConstruct::AZ,
+            b"qAI" => QConstruct::AI,
+            _ => return None,
+        };
+
+        Some(q)
+    }
+
+    pub fn as_textual(&self) -> &'static str {
+        match self {
+            QConstruct::AC => "qAC",
+            QConstruct::AX => "qAX",
+            QConstruct::AU => "qAU",
+            QConstruct::Ao => "qAo",
+            QConstruct::AO => "qAO",
+            QConstruct::AS => "qAS",
+            QConstruct::Ar => "qAr",
+            QConstruct::AR => "qAR",
+            QConstruct::AZ => "qAZ",
+            QConstruct::AI => "qAI",
+        }
+    }
+}


### PR DESCRIPTION
APRS has 2 main representations.
- Textual: Usually used for interfacing with APRS-IS
- Binary: Usually used for transmission over the air

This PR adds binary encoding and decoding. Now this library is useful for crafting packets for local transmission instead of just sending them to the APRS-IS network.