### PR TITLE
add data type identifier method to AprsData

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //!                 ],
 //!                 data: AprsData::Position(
 //!                     AprsPosition {
+//!                         data_type_identifier: b'/',
 //!                         to: Callsign::new_no_ssid("APRS"),
 //!                         timestamp: Some(
 //!                             Timestamp::HHMMSS(

--- a/src/message.rs
+++ b/src/message.rs
@@ -7,6 +7,7 @@ use EncodeError;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AprsMessage {
     pub to: Callsign,
+    pub data_type_identifier: u8,
 
     pub addressee: Vec<u8>,
     pub text: Vec<u8>,
@@ -37,6 +38,7 @@ impl AprsMessage {
 
         Ok(Self {
             to,
+            data_type_identifier: b':',
 
             addressee,
             text,
@@ -110,6 +112,7 @@ mod tests {
                 to: default_callsign(),
                 addressee: b"DESTINATI".to_vec(),
                 id: Some(b"329A7D5Z4".to_vec()),
+                data_type_identifier: b':',
                 text: b"Hello World! This msg has a : colon ".to_vec()
             })
         );
@@ -128,6 +131,7 @@ mod tests {
                 to: default_callsign(),
                 addressee: b"DESTINATI".to_vec(),
                 id: Some(vec![]),
+                data_type_identifier: b':',
                 text: b"Hello World! This msg has a : colon ".to_vec()
             })
         );
@@ -146,7 +150,8 @@ mod tests {
                 to: default_callsign(),
                 addressee: b"DESTINATI".to_vec(),
                 id: None,
-                text: b"Hello World! This msg has a : colon ".to_vec()
+                text: b"Hello World! This msg has a : colon ".to_vec(),
+                data_type_identifier: b':',
             })
         );
     }

--- a/src/mic_e.rs
+++ b/src/mic_e.rs
@@ -150,10 +150,16 @@ pub struct AprsMicE {
     pub comment: Vec<u8>,
 
     pub current: bool,
+    pub data_type_identifier: u8,
 }
 
 impl AprsMicE {
-    pub fn decode(b: &[u8], to: Callsign, current: bool) -> Result<Self, DecodeError> {
+    pub fn decode(
+        data_type_identifier: u8,
+        b: &[u8],
+        to: Callsign,
+        current: bool,
+    ) -> Result<Self, DecodeError> {
         let (latitude, precision, message, long_offset, long_dir) =
             decode_callsign(&to).ok_or(DecodeError::InvalidMicEDestination(to))?;
 
@@ -170,6 +176,7 @@ impl AprsMicE {
         let symbol_table = info[7];
 
         Ok(Self {
+            data_type_identifier,
             latitude,
             longitude,
             precision,
@@ -569,10 +576,11 @@ mod tests {
         let information = &br#"(_fn"Oj/Hello world!"#[..];
         let to = Callsign::new_no_ssid("PPPPPP");
 
-        let data = AprsMicE::decode(information, to.clone(), true).unwrap();
+        let data = AprsMicE::decode(b'`', information, to.clone(), true).unwrap();
 
         assert_eq!(
             AprsMicE {
+                data_type_identifier: b'`',
                 latitude: Latitude::new(0.0).unwrap(),
                 longitude: Longitude::new(-112.12899999999999).unwrap(),
                 precision: Precision::HundredthMinute,
@@ -600,7 +608,7 @@ mod tests {
         let information = &br#"(_fn"Oj/Hello world!"#[..];
         let to = Callsign::new_no_ssid("S5PPW4");
 
-        let data = AprsMicE::decode(information, to.clone(), true).unwrap();
+        let data = AprsMicE::decode(b'`', information, to.clone(), true).unwrap();
 
         assert_eq!(to, data.encode_destination());
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -199,6 +199,15 @@ impl AprsData {
             AprsData::Unknown(to) => Some(to),
         }
     }
+    pub fn data_type_identifier(&self) -> u8 {
+        match self {
+            AprsData::Position(p) => p.data_type_identifier,
+            AprsData::MicE(m) => m.data_type_identifier,
+            AprsData::Message(m) => m.data_type_identifier,
+            AprsData::Status(s) => s.data_type_identifier,
+            AprsData::Unknown(_) => 0x00,
+        }
+    }
 
     fn dest_field(&self) -> Cow<Callsign> {
         match self {
@@ -211,12 +220,13 @@ impl AprsData {
     }
 
     fn decode(s: &[u8], to: Callsign) -> Result<Self, DecodeError> {
-        Ok(match *s.first().unwrap_or(&0) {
+        let identifier = s.first().unwrap_or(&0);
+        Ok(match identifier {
             b':' => AprsData::Message(AprsMessage::decode(&s[1..], to)?),
             b'!' | b'/' | b'=' | b'@' => AprsData::Position(AprsPosition::decode(s, to)?),
             b'>' => AprsData::Status(AprsStatus::decode(&s[1..], to)?),
-            0x1c | b'`' => AprsData::MicE(AprsMicE::decode(&s[1..], to, true)?),
-            0x1d | b'\'' => AprsData::MicE(AprsMicE::decode(&s[1..], to, false)?),
+            0x1c | b'`' => AprsData::MicE(AprsMicE::decode(*identifier, &s[1..], to, true)?),
+            0x1d | b'\'' => AprsData::MicE(AprsMicE::decode(*identifier, &s[1..], to, false)?),
             _ => AprsData::Unknown(to),
         })
     }
@@ -378,6 +388,7 @@ mod tests {
                     Via::Callsign(Callsign::new_with_ssid("DB0KOE", "12"), false)
                 ],
                 data: AprsData::MicE(AprsMicE {
+                    data_type_identifier: b'`',
                     latitude: Latitude::new(51.041).unwrap(),
                     longitude: Longitude::new(6.495833333333334).unwrap(),
                     precision: Precision::HundredthMinute,

--- a/src/position.rs
+++ b/src/position.rs
@@ -85,7 +85,7 @@ impl Default for Precision {
 #[derive(PartialEq, Debug, Clone)]
 pub struct AprsPosition {
     pub to: Callsign,
-
+    pub data_type_identifier: u8,
     pub timestamp: Option<Timestamp>,
     pub messaging_supported: bool,
 
@@ -135,12 +135,13 @@ impl AprsPosition {
         // check for compressed position format
         let is_uncompressed_position = (*b.first().unwrap_or(&0) as char).is_numeric();
         match is_uncompressed_position {
-            true => Self::parse_uncompressed(b, to, timestamp, messaging_supported),
-            false => Self::parse_compressed(b, to, timestamp, messaging_supported),
+            true => Self::parse_uncompressed(first, b, to, timestamp, messaging_supported),
+            false => Self::parse_compressed(first, b, to, timestamp, messaging_supported),
         }
     }
 
     fn parse_compressed(
+        type_identifier: u8,
         b: &[u8],
         to: Callsign,
         timestamp: Option<Timestamp>,
@@ -178,6 +179,7 @@ impl AprsPosition {
 
         Ok(Self {
             to,
+            data_type_identifier: type_identifier,
             timestamp,
             messaging_supported,
             latitude,
@@ -191,6 +193,7 @@ impl AprsPosition {
     }
 
     fn parse_uncompressed(
+        type_identifier: u8,
         b: &[u8],
         to: Callsign,
         timestamp: Option<Timestamp>,
@@ -210,6 +213,7 @@ impl AprsPosition {
         let comment = b[19..].to_owned();
 
         Ok(Self {
+            data_type_identifier: type_identifier,
             to,
             timestamp,
             messaging_supported,

--- a/src/status.rs
+++ b/src/status.rs
@@ -19,6 +19,7 @@ use Timestamp;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AprsStatus {
     pub to: Callsign,
+    pub data_type_identifier: u8,
 
     timestamp: Option<Timestamp>,
     comment: Vec<u8>,
@@ -29,6 +30,7 @@ impl AprsStatus {
         let timestamp = timestamp.map(|t| t.into());
         Self {
             to,
+            data_type_identifier: b'>',
             timestamp,
             comment,
         }
@@ -39,6 +41,7 @@ impl AprsStatus {
     /// Use this function to create an AprsStatus with any timestamp type
     pub fn new_noncompliant(to: Callsign, timestamp: Option<Timestamp>, comment: Vec<u8>) -> Self {
         Self {
+            data_type_identifier: b'>',
             to,
             timestamp,
             comment,
@@ -68,6 +71,7 @@ impl AprsStatus {
 
         Ok(AprsStatus {
             to,
+            data_type_identifier: b'>',
             timestamp,
             comment: comment.to_owned(),
         })


### PR DESCRIPTION
In my usecase aprs messages gets filtered by the data type however once parsed this information was gone in aprs_parser.
Before this pr only way to get this information was to manually reparsing package