### PR TITLE
remove ssids that are 0

### DIFF
--- a/src/callsign.rs
+++ b/src/callsign.rs
@@ -44,7 +44,7 @@ impl Callsign {
         let call = call.into();
         let ssid = ssid.into();
 
-        let ssid = if ssid == "0" { None } else { Some(ssid.into()) };
+        let ssid = if ssid == "0" { None } else { Some(ssid) };
 
         Callsign { call, ssid }
     }

--- a/src/callsign.rs
+++ b/src/callsign.rs
@@ -42,7 +42,10 @@ impl Callsign {
 
     pub fn new_with_ssid(call: impl Into<String>, ssid: impl Into<String>) -> Callsign {
         let call = call.into();
-        let ssid = Some(ssid.into());
+        let ssid = ssid.into();
+
+        let ssid = if ssid == "0" { None } else { Some(ssid.into()) };
+
         Callsign { call, ssid }
     }
 
@@ -220,6 +223,11 @@ mod tests {
         assert_eq!(
             Callsign::decode_textual(&b"ABCDEF-2"[..]),
             Some((Callsign::new_with_ssid("ABCDEF", "2"), false))
+        );
+
+        assert_eq!(
+            Callsign::decode_textual(&b"ABCDEF-0"[..]),
+            Some((Callsign::new_no_ssid("ABCDEF"), false))
         );
     }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -423,6 +423,33 @@ mod tests {
     }
 
     #[test]
+    fn encode_with_ssid_0() {
+        let packet = AprsPacket {
+            from: Callsign::new_with_ssid("D9KS3", "0"),
+            via: vec![Via::Callsign(Callsign::new("D9KS7-0").unwrap(), false)],
+            data: AprsData::Position(AprsPosition {
+                to: Callsign::new_with_ssid("NOBODY", "0"),
+                timestamp: None,
+                messaging_supported: true,
+                latitude: Latitude::new(3.95).unwrap(),
+                longitude: Longitude::new(-4.58).unwrap(),
+                precision: Precision::HundredthMinute,
+                symbol_table: '/',
+                symbol_code: 'c',
+                comment: b"Hello world".to_vec(),
+                cst: AprsCst::Uncompressed,
+            }),
+        };
+
+        let mut buf = vec![];
+        packet.encode_textual(&mut buf).unwrap();
+        assert_eq!(
+            "D9KS3>NOBODY,D9KS7:=0357.00N/00434.80WcHello world",
+            String::from_utf8(buf).unwrap()
+        );
+    }
+
+    #[test]
     fn e2e_serialize_deserialize() {
         let valids = vec![
             r"3D17F2>APRS,qAS,DL4MEA:/074849h4821.61N\01224.49E^322/103/A=003054 !W09! id213D17F2 -039fpm +0.0rot 2.5dB 3e -0.0kHz gps1x1",


### PR DESCRIPTION
Apparently SSIDs that are 0 aren't really allowed when it's specified explicitly: https://aprs-is.net/Connecting.aspx

>  A SSID of zero is assumed if the callsign does not have a SSID; therefore never explicitly define -0 as a SSID.

This causes some APRS-IS gateways to reject these packets. The fix is to remove SSIDs of 0.