### PR TITLE
Updated altitudes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aprs-parser"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "approx",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aprs-parser"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Tobias Bieniek <tobias.bieniek@gmail.com>"]
 description = "APRS message parser for Rust"
 readme = "README.md"

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,11 +1,51 @@
-use aprs_parser::AprsPacket;
+use aprs_parser::{AprsData, AprsPacket};
 
 extern crate aprs_parser;
 
 fn main() {
-    let result = AprsPacket::decode_textual(
-        br"IC17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054",
-    );
 
-    println!("{:#?}", result);
+    let packets = vec![
+        r##"WA6IFI-12>APN391,PVLY,WIDE2-1:!3846.33N110459.55W#PHG3830 WA6IFI W2,COn /A12349"##,
+        r##"KC5W>SYSRSQ,W0NED,WIDE1,WIDE2-1:`qXxl -/`_4"##,
+        r##"K0MKX>SYTPUV,WD4IXD-2,WIDE1,N0SZ-2,WIDE2:`q`Ul Q./`"G@}Say hello 146.52...._4"##,
+        r##"AE0SS-2>APZEOS,EOSS,WIDE2-1:/175008h3902.30N/10308.43WO287/000/A=005143 320T8472P EOSS BALLOON"##,
+        r##"WD0AJG-6>SY0SSW,WA6IFI-12,PVLY,WIDE2:`pO$r]Sj/`"Jv}OnTheRoadAgain_%"##,
+        r##"N0SZ-2>APMI06,W0NED,NCFPD,WIDE2:@211337z3915.89NI10506.85W#PHG5130/Devils Head Digi/I-Gate12.3V,26.3C/79.3F/A=009150"##,
+        r##"IC17F2>APRS,qAS,dl4mea:/074849h4821.61N\01224.49E^322/103/A=003054"##,
+        r##"N0SZ-2>APMI06,W0NED,NCFPD,WIDE2:@242017z3915.89NI10506.85W#PHG5130/Devils Head Digi/I-Gate12.3V,27.1C/80.7F/A=009150"##,
+        r##"WA0DE-9>S9RSVQ,WIDE1-1,WIDE2-1:`pDMx#/"J%}ARESDEC CommTrailer"##,
+        r##"K0RAP-9>SYTWZZ,W0NED,WIDE1:`pKo>(>/`"F(}147.210MHz C100 +060 http://www.k0rap.com_4"##,
+        r##"WD0AJG-9>SY3SQR,WQ8M-9,WIDE1,WIDE2-1:`pQPmp>/`"GO}OnTheRoadAgain-146.52 or scan local RPT_1"##,
+        r##"W8XAL-10>TPSTWW,W0NED,WIDE1,NCFPD,WIDE2:`pWvl!:>\`"3O}438.025MHz C088 -500 The truth is out there. _1"##,
+    ];
+
+    for p in packets {
+        println!("\n=========================");
+        println!("PACKET:  {:?}", p);
+
+        /*
+        match String::from_utf8(p.into()) {
+            Ok(s) => println!("utf8: {}", s),
+            Err(e) => println!("Unable to convert to utf-8: {}", e),
+        };
+        */
+
+        if let Ok(packet) = AprsPacket::decode_textual(p.as_bytes()) {
+            println!("{:?}\n", &packet);
+
+            match packet.data {
+                AprsData::Position(pos_packet) => {
+                    if let Some(alt) = pos_packet.position.altitude {
+                        println!("ALTITUDE: {}", alt.altitude_feet());
+                    }
+                },
+                AprsData::MicE(mice_packet) => {
+                    if let Some(alt) = mice_packet.altitude {
+                        println!("ALTITUDE: {}", alt.altitude_feet());
+                    }
+                },
+                _ => println!("Unknown packet"),
+            }
+        };
+    }
 }

--- a/src/components/position.rs
+++ b/src/components/position.rs
@@ -1,9 +1,12 @@
 use std::{
     io::{Read, Write},
     ops::RangeInclusive,
+    str,
 };
 
 use crate::{AprsCompressedCs, AprsCompressionType, DecodeError, EncodeError};
+
+use AprsAltitude;
 
 use super::lonlat::{Latitude, Longitude, Precision};
 
@@ -25,6 +28,7 @@ pub struct Position {
     pub symbol_table: char,
     pub symbol_code: char,
     pub cst: AprsCst,
+    pub altitude: Option<AprsAltitude>,
 }
 
 impl Position {
@@ -62,6 +66,35 @@ impl Position {
 
         Ok(())
     }
+
+    pub(crate) fn altitude_in_comment(data: &[u8]) -> Option<AprsAltitude> {
+        // Convert to a string slice. 
+        let s = str::from_utf8(data).ok()?;
+
+        // Find the starting index of the "/A=" substring. 
+        let start_index = s.find("/A=")?;
+
+        // Calculate the index where the number begins.
+        let number_start_index = start_index + "/A=".len();
+
+        // Get a slice of the string from that point onward.
+        let rest = &s[number_start_index..];
+
+        // Find the end of the number by searching for the first non-digit character.
+        let number_end_index = rest.find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(rest.len());
+
+        // Slice the string to get only the number part.
+        let number_str = &rest[..number_end_index];
+
+        // Parse the number string. If parsing fails, return None.
+        let altitude_value = number_str.parse::<u32>().ok()?;
+
+        // return a new AprsAltitude struct
+        Some(AprsAltitude::new(altitude_value as f64))
+    }
+
+
     /// this function assumes we are getting the head of a byte list
     /// representing a compressed or uncompressed position
     ///
@@ -82,6 +115,9 @@ impl Position {
 
             let symbol_table = b[8] as char;
             let symbol_code = b[18] as char;
+            
+            // search the comment field for an altitude (e.g. '/A=aaaaaa')
+            let altitude = Position::altitude_in_comment(&b[19..]);
 
             Ok((
                 b.get(19..),
@@ -92,6 +128,7 @@ impl Position {
                     symbol_code,
                     symbol_table,
                     cst: AprsCst::Uncompressed,
+                    altitude,
                 },
             ))
         } else {
@@ -123,6 +160,9 @@ impl Position {
                     AprsCst::CompressedSome { cs, t }
                 }
             };
+
+            let altitude = None;
+            
             Ok((
                 b.get(13..),
                 Self {
@@ -132,6 +172,7 @@ impl Position {
                     symbol_code,
                     symbol_table,
                     cst,
+                    altitude,
                 },
             ))
         }

--- a/src/components/position.rs
+++ b/src/components/position.rs
@@ -161,8 +161,15 @@ impl Position {
                 }
             };
 
-            let altitude = None;
-            
+            // get the altitude value
+            let altitude: Option<AprsAltitude> = match cst {
+                AprsCst::CompressedSome{cs, ..} => match cs {
+                    AprsCompressedCs::Altitude(a) => Some(a),
+                    _ => None,
+                },
+                _ => None,
+            };
+
             Ok((
                 b.get(13..),
                 Self {

--- a/src/compressed_cs.rs
+++ b/src/compressed_cs.rs
@@ -150,6 +150,10 @@ impl AprsAltitude {
         Self { altitude_feet }
     }
 
+    pub fn altitude_meters(&self) -> f64 {
+        self.altitude_feet * 0.3048
+    }
+
     pub fn altitude_feet(&self) -> f64 {
         self.altitude_feet
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! extern crate aprs_parser;
 //!
-//! use aprs_parser::{AprsCst, AprsData, AprsPacket, AprsPosition, Callsign, Latitude, Longitude, Precision, Timestamp, Via, QConstruct, Position};
+//! use aprs_parser::{AprsCst, AprsData, AprsPacket, AprsPosition, AprsAltitude, Callsign, Latitude, Longitude, Precision, Timestamp, Via, QConstruct, Position, Extension::DirectionSpeed};
 //!
 //! fn main() {
 //!     let result = AprsPacket::decode_textual(
@@ -42,8 +42,10 @@
 //!                             symbol_table: '\\',
 //!                             symbol_code: '^',
 //!                             cst: AprsCst::Uncompressed,
+//!                             altitude: Some(AprsAltitude::new(3054.0)),
 //!                         },
 //!                         comment: b"322/103/A=003054".to_vec(),
+//!                         extension: Some(DirectionSpeed { direction_degrees: 322, speed_knots: 3 }),
 //!                     }
 //!                 )
 //!             }

--- a/src/mic_e.rs
+++ b/src/mic_e.rs
@@ -152,6 +152,10 @@ pub struct AprsMicE {
 
     pub current: bool,
     pub altitude: Option<AprsAltitude>,
+    pub radio_mfg: Option<Vec<u8>>,  // some radios, notably Kenwood use a radio identification char
+                                 // between the symbol code and the Mic-e status field.  However, 
+                                 // also using this as a catch-all for any data between the symbol
+                                 // code and any altitude value found.
 }
 
 impl AprsMicE {
@@ -182,18 +186,22 @@ impl AprsMicE {
         // the altitude
         let mut altitude = None;
 
+        // the radio manufacturer character
+        let mut radio_mfg = None;
+
         // if the rest of the packet (i.e. the information field) is present, then try and decode
         if rest_of_packet.len() > 2 {
 
-            // most radios insert a manufacturer character at the beginning of the status field.
-            let _radio_manufacturer_char = rest_of_packet[0];  // might want to do something with
-                                                               // this at some point in the future.
-            let starting_status_index = 0;
-
             // is an altitude embedded within the status field?
-            let (idx, alt) = decode_altitude(&rest_of_packet[starting_status_index..]);
+            let (idx, alt) = decode_altitude(&rest_of_packet[0..]);
             comment_start = match idx {
-                Some(i) => i+1, 
+                Some(i) => {
+                    if i > 3 {
+                        // some radios insert a manufacturer character at the beginning of the status field (e.g kenwood).
+                        radio_mfg = Some(rest_of_packet[0..i-3].to_vec());
+                    }
+                    i+1
+                },
                 None => 0,
             };
 
@@ -201,12 +209,6 @@ impl AprsMicE {
         }
 
         let comment = rest_of_packet[comment_start..].to_vec();
-
-        /*
-        let s = String::from_utf8_lossy(&comment);
-        println!("\nCOMMENT[{}]: {}\n", comment_start, s);
-        */
-        
 
         Ok(Self {
             latitude,
@@ -222,6 +224,7 @@ impl AprsMicE {
 
             current,
             altitude,
+            radio_mfg,
         })
     }
 
@@ -236,6 +239,18 @@ impl AprsMicE {
         self.encode_speed_and_course(buf)?;
 
         buf.write_all(&[self.symbol_code as u8, self.symbol_table as u8])?;
+
+        // encode any radio manufacturer identification character(s)
+        if let Some(mfg) = &self.radio_mfg {
+            buf.write_all(mfg)?;
+        }
+
+        // if there is an altitude defined then encode that
+        if let Some(_a) = self.altitude {
+            self.encode_altitude(buf)?;
+        }
+
+        // the comment for the APRS packet
         buf.write_all(&self.comment)?;
 
         Ok(())
@@ -322,10 +337,50 @@ impl AprsMicE {
             0..=19 => tens_knots + 80,
             _ => tens_knots,
         };
+
         let dc: u8 = (units_knots * 10 + hundreds_course + 4).try_into().unwrap();
         let se: u8 = (units_course).try_into().unwrap();
 
         w.write_all(&[sp + 28, dc + 28, se + 28])?;
+
+        Ok(())
+    }
+
+    fn encode_altitude<W: Write>(&self, w: &mut W) -> Result<(), EncodeError> {
+
+        // if there's an altitude value present
+        if let Some(a) = self.altitude {
+
+            // the altitude in meters +10000 and rounded to the nearest integer.
+            let mut dividend = (a.altitude_meters() + 10000.0).round() as u32;
+
+            // the buffer to store the list of u8 encoded values
+            let mut b = vec![];
+
+            // loop counter.
+            let mut i: i32 = 2;
+
+            while i >= 0 {
+                let divsor = 91_u32.pow(i as u32);
+                let quotient = dividend / divsor;
+                let amount = quotient * divsor;
+
+                // the quotient + 33 results in an ascii char for the encoding
+                let c = quotient + 33;
+
+                // add the character to the vector
+                b.push(c as u8);
+
+                // decrement the dividend
+                dividend -= amount;
+                
+                // decrement the loop index and continue
+                i -= 1;
+            }
+
+            b.push(b'}');
+            w.write_all(&b)?;
+        }
 
         Ok(())
     }
@@ -656,14 +711,17 @@ mod tests {
             AprsMicE {
                 latitude: Latitude::new(0.0).unwrap(),
                 longitude: Longitude::new(-112.12899999999999).unwrap(),
+                //longitude: Longitude::new(-105.07733333333333).unwrap(),
                 precision: Precision::HundredthMinute,
                 message: Message::M0,
                 speed: Speed::new(20).unwrap(),
                 course: Course::new(251).unwrap(),
-                symbol_table: b'/',
-                symbol_code: b'j',
+                symbol_table: '/',
+                symbol_code: 'j',
                 comment: b"Hello world!".to_vec(),
-                current: true
+                current: true,
+                altitude: None,
+                radio_mfg: None,
             },
             data
         );

--- a/src/mic_e.rs
+++ b/src/mic_e.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use std::io::Write;
+//use std::any::type_name;
 
 use Callsign;
 use DecodeError;
@@ -7,6 +8,7 @@ use EncodeError;
 use Latitude;
 use Longitude;
 use Precision;
+use AprsAltitude;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Message {
@@ -144,11 +146,12 @@ pub struct AprsMicE {
     pub message: Message,
     pub speed: Speed,
     pub course: Course,
-    pub symbol_table: u8,
-    pub symbol_code: u8,
+    pub symbol_table: char,
+    pub symbol_code: char,
     pub comment: Vec<u8>,
 
     pub current: bool,
+    pub altitude: Option<AprsAltitude>,
 }
 
 impl AprsMicE {
@@ -156,17 +159,54 @@ impl AprsMicE {
         let (latitude, precision, message, long_offset, long_dir) =
             decode_callsign(&to).ok_or(DecodeError::InvalidMicEDestination(to))?;
 
+        // The 'b' argument actually begins at the 2nd byte within the info field (the caller
+        // strips that first byte off for us).  That first byte is the Data Type ID and denotes 
+        // what type of content the APRS packet contains (e.g. position report, telemetry, Mic-E, etc.). 
         let info = b
             .get(0..8)
             .ok_or_else(|| DecodeError::InvalidMicEInformation(b.to_vec()))?;
-        let comment = b.get(8..).unwrap_or(&[]).to_vec();
+
+        // the remainder of the packet
+        let rest_of_packet = b.get(8..).unwrap_or(&[]).to_vec();
 
         let longitude = decode_longitude(&info[0..3], long_offset, long_dir)
             .ok_or_else(|| DecodeError::InvalidMicEInformation(b.to_vec()))?;
         let (speed, course) = decode_speed_and_course(&info[3..6])
             .ok_or_else(|| DecodeError::InvalidMicEInformation(b.to_vec()))?;
-        let symbol_code = info[6];
-        let symbol_table = info[7];
+        let symbol_code = info[6] as char;
+        let symbol_table = info[7] as char;
+
+        // starting point the "comment" portion of the packet
+        let mut comment_start = 0;
+
+        // the altitude
+        let mut altitude = None;
+
+        // if the rest of the packet (i.e. the information field) is present, then try and decode
+        if rest_of_packet.len() > 2 {
+
+            // most radios insert a manufacturer character at the beginning of the status field.
+            let _radio_manufacturer_char = rest_of_packet[0];  // might want to do something with
+                                                               // this at some point in the future.
+            let starting_status_index = 0;
+
+            // is an altitude embedded within the status field?
+            let (idx, alt) = decode_altitude(&rest_of_packet[starting_status_index..]);
+            comment_start = match idx {
+                Some(i) => i+1, 
+                None => 0,
+            };
+
+            altitude = alt
+        }
+
+        let comment = rest_of_packet[comment_start..].to_vec();
+
+        /*
+        let s = String::from_utf8_lossy(&comment);
+        println!("\nCOMMENT[{}]: {}\n", comment_start, s);
+        */
+        
 
         Ok(Self {
             latitude,
@@ -181,6 +221,7 @@ impl AprsMicE {
             comment,
 
             current,
+            altitude,
         })
     }
 
@@ -194,7 +235,7 @@ impl AprsMicE {
         self.encode_longitude(buf)?;
         self.encode_speed_and_course(buf)?;
 
-        buf.write_all(&[self.symbol_code, self.symbol_table])?;
+        buf.write_all(&[self.symbol_code as u8, self.symbol_table as u8])?;
         buf.write_all(&self.comment)?;
 
         Ok(())
@@ -459,6 +500,47 @@ fn decode_speed_and_course(b: &[u8]) -> Option<(Speed, Course)> {
 
     Some((speed, course))
 }
+
+// find the altitude within the mic-e status or telemetry portion of a packet
+fn decode_altitude(data: &[u8]) -> (Option<usize>, Option<AprsAltitude>) {
+    // sanity check
+    if data.len() < 3 {
+        return (None, None);
+    }
+
+    // find the first position of a '}' character
+    if let Some(idx) = data.iter().position(|&byte| byte == b'}') {
+
+        // only proceed if there are at least 3 characters to the left of the '}'
+        if idx >= 3 {
+
+            let mut alt: i32  = 0;
+            let mut startingidx = 0;
+            if idx - 3 > 0 {
+                startingidx = idx - 3;
+            }
+
+            // loop over each character to the left of the '}'
+            for i in (startingidx..idx).rev() {
+                alt += ((data[i] - 33) as i32) * (91_u32.pow((idx-i-1) as u32) as i32);
+            }
+
+            (Some(idx), Some(AprsAltitude::new((((alt - 10000) as f64) * 3.28084).round())))
+        }
+        else {
+            (None, None)
+        }
+    }
+    else {
+        (None, None)
+    }
+}
+
+/*
+fn type_of<T>(_: T) -> &'static str {
+    type_name::<T>()
+}
+*/
 
 // lat_digit must be an ASCII char to allow for spaces
 fn encode_bits_012(lat_digit: u8, message_bit: MessageBit) -> u8 {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -267,6 +267,7 @@ mod tests {
     use Precision;
     use QConstruct;
     use Timestamp;
+    use AprsAltitude;
 
     #[test]
     fn parse() {
@@ -400,10 +401,12 @@ mod tests {
                     message: Message::M1,
                     speed: Speed::new(64).unwrap(),
                     course: Course::new(35).unwrap(),
-                    symbol_table: b'/',
-                    symbol_code: b'>',
-                    comment: br#">"4z}="#.to_vec(),
-                    current: true
+                    symbol_table: '/',
+                    symbol_code: '>',
+                    comment: br#"="#.to_vec(),
+                    current: true,
+                    altitude: Some(AprsAltitude::new(325.0)),
+                    radio_mfg: Some(br#">"#.to_vec()),
                 })
             },
             result
@@ -426,8 +429,9 @@ mod tests {
                     symbol_table: '/',
                     symbol_code: 'c',
                     cst: AprsCst::Uncompressed,
+                    altitude: None,
                 },
-
+                extension: None,
                 comment: b"Hello world".to_vec(),
             }),
         };
@@ -456,7 +460,9 @@ mod tests {
                     symbol_table: '/',
                     symbol_code: 'c',
                     cst: AprsCst::Uncompressed,
+                    altitude: None,
                 },
+                extension: None,
                 comment: b"Hello world".to_vec(),
             }),
         };
@@ -481,8 +487,11 @@ mod tests {
             r"IC17F2>APRS,qAS,DL4MEA::DESTINATI:Hello World! This msg has a : colon ",
             r"ICA7F2>APRS,qAS,DL4MEA:>312359zStatus seems okay!",
             r"ICA3F2>APRS,qAS,DL4MEA:>184050hAlso with HMS format...",
-            "VE9MP-12>T5RX8P,VE9GFI-2,WIDE1*,WIDE2-1,qAR,VE9QLE-10:`]Q\x1cl|ok/'\"4<}Nick - Monitoring IRG|!\"&7'M|!wTD!|3",
-            r#"DF1CHB-9>UQ0RT6,ARISS,APRSAT,WIDE1-1,qAU,DB0KOE-1:`|9g\"H?>/>\"4z}="#,
+            r#"WN6OTL>T0PYTU,W0UPS-15,WIDE1,NCFPD,WIDE2:`pUbl!X>/'"D7}|!G%G'g|!w6D!|3"#,
+            r#"N0JME>T0RVQP,W0UPS-15,WIDE1,NCFPD,WIDE2:`pF}l"b>/'"CQ}MT-RTG|&K%L'b|!wd'!|3"#,
+            r#"K1DDN-9>S8TXRT,BADGR,NCFPD,WIDE2:`qDEmA5k/]"U[}CQ FIELD DAY="#,
+            r#"VE9MP-12>T5RX8P,VE9GFI-2,WIDE1*,WIDE2-1,qAR,VE9QLE-10:`]Ql|ok/'"4<}Nick - Monitoring IRG|!"&7'M|!wTD!|3"#,
+            r#"DF1CHB-9>UQ0RT6,ARISS,APRSAT,WIDE1-1,qAU,DB0KOE-1:`|9grH?>/>"4z}="#,
         ];
 
         for v in valids {
@@ -505,8 +514,8 @@ mod tests {
             r"IC17F2>APRS,qAS,DL4MEA::DESTINATI:Hello World! This msg has a : colon ",
             r"ICA7F2>APRS,qAS,DL4MEA:>312359zStatus seems okay!",
             r"ICA3F2>APRS,qAS,DL4MEA:>184050hAlso with HMS format...",
-            "VE9MP-12>T5RX8P,VE9GFI-2,WIDE1*,WIDE2-1,qAR,VE9QLE-10:`]Q\x1cl|ok/'\"4<}Nick - Monitoring IRG|!\"&7'M|!wTD!|3",
-            r#"DF1CHB-9>UQ0RT6,ARISS,APRSAT,WIDE1-1,qAU,DB0KOE-1:`|9g\"H?>/>\"4z}="#,
+            r#"VE9MP-12>T5RX8P,VE9GFI-2,WIDE1*,WIDE2-1,qAR,VE9QLE-10:`]Ql|ok/'"4<}Nick - Monitoring IRG|!"&7'M|!wTD!|3"#,
+            r#"DF1CHB-9>UQ0RT6,ARISS,APRSAT,WIDE1-1,qAU,DB0KOE-1:`|9grH?>/>\"4z}="#,
             // 0 to 8 via callsigns
             r"ICA3F2>APRS:>184050hAlso with HMS format...",
             r"ICA3F2>APRS,qAS:>184050hAlso with HMS format...",
@@ -531,8 +540,8 @@ mod tests {
             r"IC17F2>APRS,DL4MEA::DESTINATI:Hello World! This msg has a : colon ",
             r"ICA7F2>APRS,DL4MEA:>312359zStatus seems okay!",
             r"ICA3F2>APRS,DL4MEA:>184050hAlso with HMS format...",
-            "VE9MP-12>T5RX8P,VE9GFI-2,WIDE1*,WIDE2-1,VE9QLE-10:`]Q\x1cl|ok/'\"4<}Nick - Monitoring IRG|!\"&7'M|!wTD!|3",
-            r#"DF1CHB-9>UQ0RT6,ARISS,APRSAT,WIDE1-1,DB0KOE-1:`|9g\"H?>/>\"4z}="#,
+            r#"VE9MP-12>T5RX8P,VE9GFI-2,WIDE1*,WIDE2-1,VE9QLE-10:`]Ql|ok/'"4<}Nick - Monitoring IRG|!"&7'M|!wTD!|3"#,
+            r#"DF1CHB-9>UQ0RT6,ARISS,APRSAT,WIDE1-1,DB0KOE-1:`|9grH?>/>\"4z}="#,
             // 0 to 8 via callsigns
             r"ICA3F2>APRS:>184050hAlso with HMS format...",
             r"ICA3F2>APRS:>184050hAlso with HMS format...",

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -207,7 +207,7 @@ impl AprsData {
         }
     }
 
-    fn dest_field(&self) -> Cow<Callsign> {
+    fn dest_field(&self) -> Cow<'_, Callsign> {
         match self {
             AprsData::Position(p) => Cow::Borrowed(&p.to),
             AprsData::Message(m) => Cow::Borrowed(&m.to),

--- a/src/position.rs
+++ b/src/position.rs
@@ -5,6 +5,7 @@ use Callsign;
 use DecodeError;
 use EncodeError;
 use Timestamp;
+use Extension;
 
 use Position;
 
@@ -13,13 +14,11 @@ use AprsCst;
 #[derive(PartialEq, Debug, Clone)]
 pub struct AprsPosition {
     pub to: Callsign,
-
     pub timestamp: Option<Timestamp>,
     pub messaging_supported: bool,
-
     pub position: Position,
-
     pub comment: Vec<u8>,
+    pub extension: Option<Extension>,
 }
 
 impl AprsPosition {
@@ -45,8 +44,12 @@ impl AprsPosition {
 
         // decode the position and symbol data
         let (remaining_buffer, position) = Position::decode(b)?;
+
         // comment is entire rest of buffer, blank comment if not provided
         let comment = remaining_buffer.unwrap_or_default().to_vec();
+
+        // try and parse comment field for an extension
+        let extension = Extension::decode(&comment).ok();
 
         Ok(Self {
             to,
@@ -54,8 +57,10 @@ impl AprsPosition {
             messaging_supported,
             position,
             comment,
+            extension,
         })
     }
+
 
     pub fn encode<W: Write>(&self, buf: &mut W) -> Result<(), EncodeError> {
         let sym = match (self.timestamp.is_some(), self.messaging_supported) {


### PR DESCRIPTION
Update to parse altitudes in the comment section of packets as well as handling some oddities with some radios that include a manufacturer's character within the packet.  Added an `altitude` field to the `Position` struct to accommodate altitude values:
```
pub struct Position {
    pub latitude: Latitude,
    pub longitude: Longitude,
    pub precision: Precision,
    pub symbol_table: char,
    pub symbol_code: char,
    pub cst: AprsCst,
    pub altitude: Option<AprsAltitude>,
}
```
